### PR TITLE
chore: apply code review suggestions, qol changes

### DIFF
--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -121,18 +121,18 @@ This request can be sent by the Certificate Consumer continuously, for updates o
 
 ```json
 {
-  "header" : {
-    "senderBpn" : "BPNL0000000001AB",
-    "context" : "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
-    "messageId" : "e94eaa84-6fb3-4693-a189-201a20dfcecf",
-    "receiverBpn" : "BPNL0000000002CD",
-    "sentDateTime" : "2025-05-04T00:00:00-07:00",
-    "version" : "3.1.0"
+  "header": {
+    "senderBpn": "BPNL0000000001AB",
+    "context": "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
+    "messageId": "e94eaa84-6fb3-4693-a189-201a20dfcecf",
+    "receiverBpn": "BPNL0000000002CD",
+    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "version": "3.1.0"
   },
   "content": {
-    "certifiedBpn" : "BPNL00000003AYRE",
-    "certificateType" : "ISO9001",
-    "locationBpns" : [ 
+    "certifiedBpn": "BPNL00000003AYRE",
+    "certificateType": "ISO9001",
+    "locationBpns": [
       "BPNA000000000001",
       "BPNA000000000002",
       "BPNS000000000003"
@@ -165,17 +165,17 @@ Case: Certificate Request Still In Process
 
 ```json
 {
-  "header" : {
-    "senderBpn" : "BPNL0000000001AB",
-    "relatedMessageId" : "04df602b-fc4e-48fc-b455-8c8159db862f",
-    "context" : "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
-    "messageId" : "b53a4682-6cb5-48f3-b3fa-0bf20718dc52",
-    "receiverBpn" : "BPNL0000000002CD",
-    "sentDateTime" : "2025-05-04T00:00:00-07:00",
-    "version" : "3.1.0"
+  "header": {
+    "senderBpn": "BPNL0000000001AB",
+    "relatedMessageId": "04df602b-fc4e-48fc-b455-8c8159db862f",
+    "context": "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
+    "messageId": "b53a4682-6cb5-48f3-b3fa-0bf20718dc52",
+    "receiverBpn": "BPNL0000000002CD",
+    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "version": "3.1.0"
   },
-  "content" : {
-    "requestStatus":"IN_PROGRESS"
+  "content": {
+    "requestStatus": "IN_PROGRESS"
   }
 }
 ```
@@ -188,17 +188,17 @@ This simplifies finding the correct offer for the requested certificate.
 
 ```json
 {
-  "header" : {
-    "senderBpn" : "BPNL0000000001AB",
-    "context" : "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
-    "messageId" : "07a71867-f05e-4b6a-9944-2531b854c40a",
-    "receiverBpn" : "BPNL0000000002CD",
-    "sentDateTime" : "2025-05-04T00:00:00-07:00",
-    "version" : "3.1.0"
+  "header": {
+    "senderBpn": "BPNL0000000001AB",
+    "context": "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
+    "messageId": "07a71867-f05e-4b6a-9944-2531b854c40a",
+    "receiverBpn": "BPNL0000000002CD",
+    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "version": "3.1.0"
   },
   "content": {
-   "documentId" : "00000000-0000-0000-0000-000000000001",
-   "requestStatus":"COMPLETED"
+    "documentId": "00000000-0000-0000-0000-000000000001",
+    "requestStatus": "COMPLETED"
   }
 }
 ```
@@ -216,23 +216,34 @@ The error message is free text.
 
 ```json
 {
-  "header" : {
-    "senderBpn" : "BPNL0000000001AB",
-    "relatedMessageId" : "c8592721-5f8e-4b3f-91ba-57f614bc06f2",
-    "context" : "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
-    "messageId" : "0ee9c20f-a55e-43c9-9a3f-0cb23d4f134d",
-    "receiverBpn" : "BPNL0000000002CD",
-    "sentDateTime" : "2025-05-04T00:00:00-07:00",
-    "version" : "3.1.0"
+  "header": {
+    "senderBpn": "BPNL0000000001AB",
+    "relatedMessageId": "c8592721-5f8e-4b3f-91ba-57f614bc06f2",
+    "context": "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
+    "messageId": "0ee9c20f-a55e-43c9-9a3f-0cb23d4f134d",
+    "receiverBpn": "BPNL0000000002CD",
+    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "version": "3.1.0"
   },
-  "content" : {
-    "requestStatus":"REJECTED",
-    "requestErrors" : [
-      {"message":"We do not process certificates on Sunday"},
-      {"message":"Can not provide certicate for requested locations"}
+  "content": {
+    "requestStatus": "REJECTED",
+    "requestErrors": [
+      {
+        "message": "We do not process certificates on Sunday"
+      },
+      {
+        "message": "Can not provide certicate for requested locations"
+      }
     ],
-    "locationErrors" : [
-        { "bpn":"BPNS000000000003", "locationErrors": [{"message":"Site BPNS000000000003 is unknown"}]}
+    "locationErrors": [
+      {
+        "bpn": "BPNS000000000003",
+        "locationErrors": [
+          {
+            "message": "Site BPNS000000000003 is unknown"
+          }
+        ]
+      }
     ]
   }
 }
@@ -248,44 +259,46 @@ The Certificate Consumer may want to send a subsequent feedback message.
 
 ```json
 {
-  "header" : {
-    "senderBpn" : "BPNL0000000001AB",
-    "senderFeedbackUrl": "https://domain.tld/path/to/edc/api/v1/dsp", 
-    "context" : "CompanyCertificateManagement-CCMAPI-Push:1.0.0",
-    "messageId" : "8bf22334-97f2-42b4-afca-f68160707b83 ",
-    "receiverBpn" : "BPNL0000000002CD",
-    "sentDateTime" : "2025-05-04T00:00:00-07:00",
-    "version" : "3.1.0"
+  "header": {
+    "senderBpn": "BPNL0000000001AB",
+    "senderFeedbackUrl": "https://domain.tld/path/to/edc/api/v1/dsp",
+    "context": "CompanyCertificateManagement-CCMAPI-Push:1.0.0",
+    "messageId": "8bf22334-97f2-42b4-afca-f68160707b83 ",
+    "receiverBpn": "BPNL0000000002CD",
+    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "version": "3.1.0"
   },
   "content": {
-    "businessPartnerNumber" : "BPNL0000000001AB",
-    "enclosedSites" : [ {
-      "areaOfApplication" : "Development, Marketing und Sales and also Procurement for interior components",
-      "enclosedSiteBpn" : "BPNS00000003AYRE"
-    } ],
-    "registrationNumber" : "12 198 54182 TMS",
-    "uploader" : "BPNL0000000001AB",
-    "document" : {
-      "documentID" : "UUID--123456789",
-      "creationDate" : "2024-08-23T13:19:00.280+02:00",
-      "contentType" : "application/pdf",
-      "contentBase64" : "iVBORw0KGgoAAdsfwerTETEfdgd"
+    "businessPartnerNumber": "BPNL0000000001AB",
+    "enclosedSites": [
+      {
+        "areaOfApplication": "Development, Marketing und Sales and also Procurement for interior components",
+        "enclosedSiteBpn": "BPNS00000003AYRE"
+      }
+    ],
+    "registrationNumber": "12 198 54182 TMS",
+    "uploader": "BPNL0000000001AB",
+    "document": {
+      "documentID": "UUID--123456789",
+      "creationDate": "2024-08-23T13:19:00.280+02:00",
+      "contentType": "application/pdf",
+      "contentBase64": "iVBORw0KGgoAAdsfwerTETEfdgd"
     },
-    "validator" : {
-      "validatorName" : "Data service provider X",
-      "validatorBpn" : "BPNL00000007YREZ"
+    "validator": {
+      "validatorName": "Data service provider X",
+      "validatorBpn": "BPNL00000007YREZ"
     },
-    "validUntil" : "2026-01-24",
-    "validFrom" : "2023-01-25",
-    "trustLevel" : "none",
-    "type" : {
-      "certificateVersion" : "2015",
-      "certificateType" : "ISO9001"
+    "validUntil": "2026-01-24",
+    "validFrom": "2023-01-25",
+    "trustLevel": "none",
+    "type": {
+      "certificateVersion": "2015",
+      "certificateType": "iso9001"
     },
-    "areaOfApplication" : "Development, Marketing und Sales and also Procurement for interior components",
-    "issuer" : {
-      "issuerName" : "TÜV",
-      "issuerBpn" : "BPNL133631123120"
+    "areaOfApplication": "Development, Marketing und Sales and also Procurement for interior components",
+    "issuer": {
+      "issuerName": "TÜV",
+      "issuerBpn": "BPNL133631123120"
     }
   }
 }
@@ -316,19 +329,19 @@ Certificate has been received by Certificate Consumer and validation is in progr
 
 ```json
 {
-  "header" : {
-    "senderBpn" : "BPNL0000000001AB",
-    "relatedMessageId" : "8284b2fc-6be3-4b90-a22a-a521eff86d0d",
-    "context" : "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
-    "messageId" : "f2cd0df7-5cdb-4a09-b273-c7cfbceccf2d",
-    "receiverBpn" : "BPNL0000000002CD",
-    "sentDateTime" : "2025-05-04T00:00:00-07:00",
-    "version" : "3.1.0"
+  "header": {
+    "senderBpn": "BPNL0000000001AB",
+    "relatedMessageId": "8284b2fc-6be3-4b90-a22a-a521eff86d0d",
+    "context": "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
+    "messageId": "f2cd0df7-5cdb-4a09-b273-c7cfbceccf2d",
+    "receiverBpn": "BPNL0000000002CD",
+    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "version": "3.1.0"
   },
   "content": {
-    "documentId" : "00000000-0000-0000-0000-000000000002",
-    "certificateStatus":"RECEIVED",
-    "locationBpns" : [
+    "documentId": "00000000-0000-0000-0000-000000000002",
+    "certificateStatus": "RECEIVED",
+    "locationBpns": [
       "BPNS000000000001",
       "BPNS000000000002",
       "BPNS000000000003",
@@ -348,19 +361,19 @@ The `locationBpns` can be a mix of sites and addresses.
 
 ```json
 {
-  "header" : {
-    "senderBpn" : "BPNL0000000001AB",
-    "relatedMessageId" : "884bb6b1-a845-4844-a87a-e178a703f127",
-    "context" : "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
-    "messageId" : "a6dca795-a1ae-4e8d-9e41-b82ebe9ebd5b",
-    "receiverBpn" : "BPNL0000000002CD",
-    "sentDateTime" : "2025-05-04T00:00:00-07:00",
-    "version" : "3.1.0"
+  "header": {
+    "senderBpn": "BPNL0000000001AB",
+    "relatedMessageId": "884bb6b1-a845-4844-a87a-e178a703f127",
+    "context": "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
+    "messageId": "a6dca795-a1ae-4e8d-9e41-b82ebe9ebd5b",
+    "receiverBpn": "BPNL0000000002CD",
+    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "version": "3.1.0"
   },
   "content": {
-    "documentId" : "00000000-0000-0000-0000-000000000001",
-    "certificateStatus":"ACCEPTED",
-    "locationBpns" : [
+    "documentId": "00000000-0000-0000-0000-000000000001",
+    "certificateStatus": "ACCEPTED",
+    "locationBpns": [
       "BPNS000000000001",
       "BPNS000000000002",
       "BPNS000000000003",
@@ -378,28 +391,42 @@ Certificate is rejected by Certificate Consumer with one or multiple reasons.
 
 ```json
 {
-  "header" : {
-    "senderBpn" : "BPNL0000000001AB",
-    "relatedMessageId" : "dde834b1-db34-4500-8e2e-d61d7b2bb527",
-    "context" : "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
-    "messageId" : "f67b9853-b714-4427-a8f3-4c53a9822da0",
-    "receiverBpn" : "BPNL0000000002CD",
-    "sentDateTime" : "2025-05-04T00:00:00-07:00",
-    "version" : "3.1.0"
+  "header": {
+    "senderBpn": "BPNL0000000001AB",
+    "relatedMessageId": "dde834b1-db34-4500-8e2e-d61d7b2bb527",
+    "context": "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
+    "messageId": "f67b9853-b714-4427-a8f3-4c53a9822da0",
+    "receiverBpn": "BPNL0000000002CD",
+    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "version": "3.1.0"
   },
-  "content" : {
-    "documentId" : "00000000-0000-0000-0000-000000000003",
-    "certificateStatus":"REJECTED",
-    "certificateErrors" : [
-      {"message":"We do not process certificates on Sunday"},
-      {"message":"Certificate has expired in 2024"},
-      {"message":"Certificate was revoked"},
-      {"message":"Unexpected data format"},
-      {"message":"Unexpected language expected English, received Mandarin"},
-      {"message":"Expected PDF, received JPG"},
-      {"message":"Unknown BPNL000000000000"}
+  "content": {
+    "documentId": "00000000-0000-0000-0000-000000000003",
+    "certificateStatus": "REJECTED",
+    "certificateErrors": [
+      {
+        "message": "We do not process certificates on Sunday"
+      },
+      {
+        "message": "Certificate has expired in 2024"
+      },
+      {
+        "message": "Certificate was revoked"
+      },
+      {
+        "message": "Unexpected data format"
+      },
+      {
+        "message": "Unexpected language expected English, received Mandarin"
+      },
+      {
+        "message": "Expected PDF, received JPG"
+      },
+      {
+        "message": "Unknown BPNL000000000000"
+      }
     ],
-    "locationBpns" : [
+    "locationBpns": [
       "BPNS000000000001",
       "BPNS000000000002",
       "BPNS000000000003",
@@ -407,9 +434,23 @@ Certificate is rejected by Certificate Consumer with one or multiple reasons.
       "BPNA000000000002",
       "BPNA000000000003"
     ],
-    "locationErrors" : [
-      { "bpn":"BPNS000000000002", "locationErrors": [{"message":"Site BPNS000000000002 has been Rejected"}]},
-      { "bpn":"BPNS000000000003", "locationErrors": [{"message":"Site BPNS000000000003 is missing"}]}
+    "locationErrors": [
+      {
+        "bpn": "BPNS000000000002",
+        "locationErrors": [
+          {
+            "message": "Site BPNS000000000002 has been Rejected"
+          }
+        ]
+      },
+      {
+        "bpn": "BPNS000000000003",
+        "locationErrors": [
+          {
+            "message": "Site BPNS000000000003 is missing"
+          }
+        ]
+      }
     ]
   }
 }
@@ -507,7 +548,7 @@ It doesn't matter if the assets are offered in one or in different connectors, a
     "dct:subject": {
       "@id": "cx-taxo:CompanyCertificateNotificationApi"
     },
-    "dct:description": "Offers API for request and pushing certificates as well as sending feedback for provided certificates.",
+    "dct:description": "Offers API for requesting and pushing certificates as well as sending feedback for provided certificates and receiving availability notifications.",
     "cx-common:version": "3.0"
   },
   "dataAddress": {},
@@ -535,49 +576,49 @@ Additionally, the assets **MUST** contain the type ```cx-taxo:Submodel``` and th
 
 ```json
 {
-    "@id": "d195fa2f-e6bc-4cd6-94d4-2bb76e4bb548",
-    "@type": "Asset",
-    "properties": {
-        "dct:type": {
-            "@id": "cx-taxo:Submodel"
-        },
-        "aas:semanticId": {
-            "@id": "urn:samm:io.catenax.business_partner_certificate:3.1.0#BusinessPartnerCertificate"
-        },
-        "dct:certificateType": {
-            "@id": "cx-taxo:ISO9001" 
-        },
-         "dct:enclosedSites": [
-            {
-                "@id": "cx-taxo:BPNS000000000001"
-            },
-            {
-                "@id": "cx-taxo:BPNS000000000002"
-            },
-            {
-                "@id": "cx-taxo:BPNA000000000001"
-            }
-         ],
-        "dct:subject": {
-            "@id": "cx-taxo:CompanyCertificate"
-        },
-        "dct:description": "Business Partner Company Certificate",
-        "cx-common:version": "3.0"
+  "@id": "d195fa2f-e6bc-4cd6-94d4-2bb76e4bb548",
+  "@type": "Asset",
+  "properties": {
+    "dct:type": {
+      "@id": "cx-taxo:Submodel"
     },
-    "dataAddress": {
-      "@type": "DataAddress",
-      "type": "HttpData",
-      "baseUrl": "https://backend-base-url/certificate-management-api-base-path",
-      "proxyQueryParams": "false",
-      "proxyPath": "false",
-      "proxyMethod": "false",
-      "proxyBody": "false"
+    "aas:semanticId": {
+      "@id": "urn:samm:io.catenax.business_partner_certificate:3.1.0#BusinessPartnerCertificate"
     },
-    "@context": {
-        "dct": "http://purl.org/dc/terms/",
-        "cx-taxo": "https://w3id.org/catenax/taxonomy#",
-        "cx-common": "https://w3id.org/catenax/ontology/common#"
-    }
+    "dct:certificateType": {
+      "@id": "cx-taxo:ISO9001"
+    },
+    "dct:enclosedSites": [
+      {
+        "@id": "cx-taxo:BPNS000000000001"
+      },
+      {
+        "@id": "cx-taxo:BPNS000000000002"
+      },
+      {
+        "@id": "cx-taxo:BPNA000000000001"
+      }
+    ],
+    "dct:subject": {
+      "@id": "cx-taxo:CompanyCertificate"
+    },
+    "dct:description": "Business Partner Company Certificate",
+    "cx-common:version": "3.0"
+  },
+  "dataAddress": {
+    "@type": "DataAddress",
+    "type": "HttpData",
+    "baseUrl": "https://backend-base-url/certificate-management-api-base-path",
+    "proxyQueryParams": "false",
+    "proxyPath": "false",
+    "proxyMethod": "false",
+    "proxyBody": "false"
+  },
+  "@context": {
+    "dct": "http://purl.org/dc/terms/",
+    "cx-taxo": "https://w3id.org/catenax/taxonomy#",
+    "cx-common": "https://w3id.org/catenax/ontology/common#"
+  }
 }
 ```
 
@@ -775,7 +816,6 @@ Applying these rules to the supported list of certificate types leads to the fol
 | AEO           | aeo         |
 | CTPAT         | ctpat       |
 | VDA6.4        | vda64       |
-
 
 #### 3.2.3 REGISTRATION AND ISSUING
 

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -21,8 +21,8 @@ This standard is relevant to the following parties:
 
 >**Context regarding the naming of involved parties:**
 >The Catena-X operating model, as well as the EDC, uses the terms `Data Consumer` and `Data Provider`.
->The EDC uses these terms in regard to the parties that offer and consume EDC assets, while the operating model uses them in the context of information flow. 
->In some cases, these understandings align, but, for example, in the case of APIs (especially the certificate push mechanism), a mismatch can occur between the two. 
+>The EDC uses these terms in regard to the parties that offer and consume EDC assets, while the operating model uses them in the context of information flow.
+>In some cases, these understandings align, but, for example, in the case of APIs (especially the certificate push mechanism), a mismatch can occur between the two.
 >To avoid misunderstandings, we use the terms `Certificate Consumer` and `Certificate Provider` to explicitly prevent this ambiguity.
 
 ## COMPARISON WITH THE PREVIOUS VERSION OF THE STANDARD
@@ -151,8 +151,8 @@ The Certificate Consumer is requesting a specific certificate from the Certifica
 | 500       | Internal Server Error.                                                    |
 
 >**EDC Behavior**:
->At the moment (standard release 25.09), the open-source EDC will always proxy a `500` internal server error when it encounters a `4xx` or `5xx` HTTP response code from the API. 
->This means that in the case of a malformed request, while the API should return a `400` status code, the final EDC response that the consumer receives will be `500`. 
+>At the moment (standard release 25.09), the open-source EDC will always proxy a `500` internal server error when it encounters a `4xx` or `5xx` HTTP response code from the API.
+>This means that in the case of a malformed request, while the API should return a `400` status code, the final EDC response that the consumer receives will be `500`.
 >Until a future EDC update changes this behavior to proxy all status codes without changes, applications will need to be able to deal with this technical reality.
 
 The detailed response bodies for HTTP Code 200 are described in 2.1.1.1.2 and following.
@@ -301,14 +301,15 @@ The Certificate Consumer may want to send a subsequent status message.
 }
 
 ```
+
 The ´senderFeedbackUrl´ specifies, where the Certificate Provider expects feedback on the status from the Certificate Consumer.
 The expected value **MUST** be a concrete path to the version 1 dataspace protocol endpoint,
 where a data offer for an asset of type cx-taxo:CCMAPI **MUST** be available for the Certificate Consumer.
 
 >**Push header `senderFeedbackUrl` explanation**:
 >This information is intended as a temporary solution to support the unique identification of multiple status endpoints across multiple EDCs belonging to one legal entity.
->The typical way to implement such differentiation in the Catena-X data space would be to provide additional, distinguishing attributes to the EDC assets to enable an automated search mechanism via the EDC discovery service and EDC catalogs. 
->Since the current changes are implemented as a non-breaking standard patch, the senderFeedbackUrl remains an intermediate solution. 
+>The typical way to implement such differentiation in the Catena-X data space would be to provide additional, distinguishing attributes to the EDC assets to enable an automated search mechanism via the EDC discovery service and EDC catalogs.
+>Since the current changes are implemented as a non-breaking standard patch, the senderFeedbackUrl remains an intermediate solution.
 >A future change is required in that regard, especially when considering the deprecation of the v1 DSP endpoint in favor of an upcoming EDC `.well-known` endpoint that supports multiple DSP versions.
 
 >**`documentID` spelling**:
@@ -352,7 +353,7 @@ Certificate has been received by Certificate Consumer and validation is in progr
 
 ##### 2.1.1.3.2 Company Certificate Status: Accepted
 
-Certificate is accepted. 
+Certificate is accepted.
 The documentId **MUST** match the documentId that was communicated by the certificate provider.
 The `locationBpns` can be a mix of sites and addresses.
 
@@ -504,7 +505,7 @@ Every dataspace participant may use their individual random uuid.
 
 > *This section is normative*
 
-The HTTP endpoints introduced in chapter [2.1.1 API endpoints and resources](#211-API-endpoints-and-resources) **MUST NOT** be called from a business partner directly. 
+The HTTP endpoints introduced in chapter [2.1.1 API endpoints and resources](#211-API-endpoints-and-resources) **MUST NOT** be called from a business partner directly.
 Rather, it **MUST** be called with any CX-0018 compliant connector via dataspace protocol.
 Therefore, the Certificate Provider **MUST** offer an asset to expose an API for Certificate Consumer in the connector catalog.
 In turn, the Certificate Consumer **MAY** offer an asset to expose an API for the Certificate Provider in the connector catalog to push certificates to.
@@ -518,19 +519,22 @@ The property [[type]](http://purl.org/dc/terms/type) **MUST** reference the name
 There **MUST** only be one unique asset per API (subject and version) across all connectors of one BPNL.
 
 *Example*: it is possible to have these assets available next to one-another:
-- ```{ "dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementNotificationApi" }, "cx-common:version": "3.0" }```, 
+
+- ```{ "dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementNotificationApi" }, "cx-common:version": "3.0" }```,
 - ```{ "dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementNotificationApi" }, "cx-common:version": "2.0" }```
 
-since they either differ in the value of the version or the subject. 
+since they either differ in the value of the version or the subject.
 But it would not be possible to have two of the same subject and the same version.
 
 *Example that is not allowed:*
+
 - ```{"dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementNotificationApi" }, "cx-common:version": "3.0" }```,
 - ```{"dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementNotificationApi" }, "cx-common:version": "3.0" }```
 
 It doesn't matter if the assets are offered in one or in different connectors, as long as they belong to the same BPNL this is not allowed.
 
 **Example Certificate Notification API**
+
 ```json
 {
   "@id": "81a0bdf8-732f-488e-bddb-1b9a78f0d1e0",
@@ -621,6 +625,7 @@ It doesn't matter if the assets are offered in one or in different connectors, a
 #### 2.1.5 MESSAGE FLOW EXPECTATIONS
 
 Certificate Provider & Certificate Consumer:
+
 - Certificate Provider **MUST** support at least one of the certificate provision mechanisms (push and/or pull mechanism)
 - Certificate Provider **MUST** expose company certificates in their catalog when using the pull mechanism.
 - Certificate Provider **MUST** set the correct access and usage policy on the certificate offer to allow consumption by Consumer(s) when using the pull mechanism.
@@ -636,6 +641,7 @@ Certificate Provider & Certificate Consumer:
 - Certificate Consumer **MAY** implement the [available endpoint](#2113-company-certificate-available) for the Certificate Provider to send availability notifications to, but **MUST** set the correct access and usage policy on the offer, when choosing to do so.
 
 Business Application Provider:
+
 - Business Application Provider **MUST** implement all features of the Certificate Notification API, including the support of the push, the pull and also the status and available mechanism.
 - Business Application Provider **MUST** offer the push mechanism option to the Certificate Consumer application user, if the Certificate Consumer supports the push mechanism.
 
@@ -644,7 +650,7 @@ Business Application Provider:
 ![PUSH Scenarios](images/certificate-push.svg)
 
 The Certificate PUSH Diagram describes the secure transmission of certificates from a Backend Certificate Provider to a Backend Certificate Consumer via EDC (Eclipse Data Connector) components.
-The process starts with a contract agreement for a Notification Asset, followed by the provider pushing the certificate to the provided endpoint in the asset.  
+The process starts with a contract agreement for a Notification Asset, followed by the provider pushing the certificate to the provided endpoint in the asset.
 The certificate is then processed by the Backend Certificate Consumer, which finalizes the workflow by generating a status message which is pushed to the provider.
 
 ##### 2.1.5.2 PULL Mechanism
@@ -652,9 +658,9 @@ The certificate is then processed by the Backend Certificate Consumer, which fin
 ![PULL Scenarios](images/certificate-pull.svg)
 
 The Certificate PULL Diagram describes the process of Consumer retrieving a certificate from a Provider via an EDC.
-It begins with the provider creating a Certificate Asset with corresponding contract definition in the EDC Catalog. 
-The Consumer searches the catalog using specific filters, initiates a contract negotiation, and retrieves the Endpoint Data Reference (EDR). 
-The Data Plane then facilitates secure data transfer, allowing the consumer to pull the certificate. 
+It begins with the provider creating a Certificate Asset with corresponding contract definition in the EDC Catalog.
+The Consumer searches the catalog using specific filters, initiates a contract negotiation, and retrieves the Endpoint Data Reference (EDR).
+The Data Plane then facilitates secure data transfer, allowing the consumer to pull the certificate.
 Once retrieved, the Backend Certificate Consumer processes the certificate and sends a status message to confirm the status.
 
 ##### 2.1.5.3 AVAILABLE notification followed by PULL mechanism
@@ -670,11 +676,12 @@ The use-case introduces the following usage purpose:
 
 - **`cx.ccm.base:1:`** *The exchanged business partner certificates are used for the purpose of verification and validation of the existence of a certification.*
 
-Additional more general usage policies **MAY** be included, 
+Additional more general usage policies **MAY** be included,
 but all the usage policies **MUST** contain the above usage purpose.
 
 *Minimal example of a usage policy without contract reference:*
-``` json
+
+```json
 {
   "@context": [
     "http://www.w3.org/ns/odrl.jsonld",

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -560,11 +560,11 @@ It doesn't matter if the assets are offered in one or in different connectors, a
 
 ##### 2.1.4.2 Certificates
 
-The certificate assets **MUST** be created by the Certificate Provider in their connector catalog to be consumed by the Certificate Consumer.
-The property certificateType **MUST** reference the type of the certificate as defined in [3.2.2 Certificate Type](#322-certificate-type).
-The property enclosedSites **MUST** contain all BPNSs for which the certificate is valid.
-The subject **MUST** reference `cx-taxo:CompanyCertificate`.
-Additionally, the assets **MUST** contain the type `cx-taxo:Submodel` and the semanticId specified in [3.1.2 Business Partner Company Certificate Submodel](#312-business-partner-company-certificate-submodel).
+- The certificate assets **MUST** be created by the Certificate Provider in their connector catalog to be consumed by the Certificate Consumer when using the pull mechanism.
+- The property certificateType **MUST** reference the type of the certificate as defined in [3.2.2 Certificate Type](#322-certificate-type).
+- The property enclosedSites **MUST** contain all BPNSs and BPNAs for which the certificate is valid.
+- The subject **MUST** reference `cx-taxo:CompanyCertificate`.
+- Additionally, the assets **MUST** contain the type `cx-taxo:Submodel` and the semanticId specified in [3.1.2 Business Partner Company Certificate Submodel](#312-business-partner-company-certificate-submodel).
 
 **Example Certificate EDC Asset:**
 

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -453,7 +453,8 @@ Certificate is rejected by Certificate Consumer with one or multiple reasons.
 
 ##### 2.1.1.3 Company Certificate Available
 
-The Certificate Consumer is notified that a certificate is available. The Certificate Consumer may want to send a subsequent GET or fetch the asset from the catalog.
+The Certificate Consumer is notified that a certificate is available.
+The Certificate Consumer may want to get the certificate via the pull mechanism.
 
 ```json
 {
@@ -633,7 +634,7 @@ Certificate Provider & Certificate Consumer:
   Certificate Provider **MUST** respond according to the [error handling](#212-error-handling).
 
 - Certificate Provider **MAY** send a notification of availability via POST /companycertificate/available after the referenced company certificate is exposed in their catalog.
-  Certificate Consumer **MUST** respond according to the [error handling](#212-error-handling).
+  Certificate Consumer **MUST** respond according to the [error handling](#212-error-handling) and **SHOULD** get the new certificate via the pull mechanism.
 - Certificate Consumer **MAY** implement the [available endpoint](#2113-company-certificate-available) for the Certificate Provider to send availability notifications to, but **MUST** set the correct access policy on the offer, when choosing to do so.
 
 Business Application Provider:

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -53,11 +53,12 @@ For avoidance of the doubt, we are not replacing the existing publication semant
 
 List for which roles the standard is relevant:
 
-- Data Provider and Consumer
+- Certificate Provider and Consumer
 - Business Application Provider
 - Enablement Service Provider
 
-This standard applies to business application providers and enablement service providers who aim to offer a solution for managing and exchanging company certificates, and returning them to customers. It is also important for data providers and consumers who need to manage and exchange certificates through a solution provider.
+This standard applies to business application providers and enablement service providers who aim to offer a solution for managing and exchanging company certificates, and returning them to customers.
+It is also important for Certificate Providers and Consumers who need to manage and exchange certificates through a solution provider.
 
 ### 1.2 CONTEXT AND ARCHITECTURE FIT
 
@@ -93,16 +94,16 @@ Today, Certificate Consumer do not have a way to request certificates from a Cer
 
 Use cases to provide certificates (from who initiates communication, negotiation and data transfer):
 
-- Certificate Consumer -> Certificate Provider : Company Certificate Pull
-- Certificate Provider -> Certificate Consumer : Company Certificate Push
+- Certificate Consumer -> Certificate Provider: Company Certificate Pull
+- Certificate Provider -> Certificate Consumer: Company Certificate Push
 
 Use case to give feedback for provided certificates:
 
-- Certificate Consumer -> Certificate Provider : Company Certificate Status (Accepted, Rejected or Received)
+- Certificate Consumer -> Certificate Provider: Company Certificate Status (Accepted, Rejected or Received)
 
 Use case to notify about availability of certificates:
 
-- Certificate Provider -> Certificate Consumer : Company Certificate Available
+- Certificate Provider -> Certificate Consumer: Company Certificate Available
 
 ### 2.1 API Specification
 

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -167,7 +167,6 @@ Case: Certificate Request Still In Process
 {
   "header": {
     "senderBpn": "BPNL0000000001AB",
-    "relatedMessageId": "04df602b-fc4e-48fc-b455-8c8159db862f",
     "context": "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
     "messageId": "b53a4682-6cb5-48f3-b3fa-0bf20718dc52",
     "receiverBpn": "BPNL0000000002CD",
@@ -218,7 +217,6 @@ The error message is free text.
 {
   "header": {
     "senderBpn": "BPNL0000000001AB",
-    "relatedMessageId": "c8592721-5f8e-4b3f-91ba-57f614bc06f2",
     "context": "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
     "messageId": "0ee9c20f-a55e-43c9-9a3f-0cb23d4f134d",
     "receiverBpn": "BPNL0000000002CD",
@@ -331,7 +329,6 @@ Certificate has been received by Certificate Consumer and validation is in progr
 {
   "header": {
     "senderBpn": "BPNL0000000001AB",
-    "relatedMessageId": "8284b2fc-6be3-4b90-a22a-a521eff86d0d",
     "context": "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
     "messageId": "f2cd0df7-5cdb-4a09-b273-c7cfbceccf2d",
     "receiverBpn": "BPNL0000000002CD",
@@ -363,7 +360,6 @@ The `locationBpns` can be a mix of sites and addresses.
 {
   "header": {
     "senderBpn": "BPNL0000000001AB",
-    "relatedMessageId": "884bb6b1-a845-4844-a87a-e178a703f127",
     "context": "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
     "messageId": "a6dca795-a1ae-4e8d-9e41-b82ebe9ebd5b",
     "receiverBpn": "BPNL0000000002CD",
@@ -393,7 +389,6 @@ Certificate is rejected by Certificate Consumer with one or multiple reasons.
 {
   "header": {
     "senderBpn": "BPNL0000000001AB",
-    "relatedMessageId": "dde834b1-db34-4500-8e2e-d61d7b2bb527",
     "context": "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
     "messageId": "f67b9853-b714-4427-a8f3-4c53a9822da0",
     "receiverBpn": "BPNL0000000002CD",

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -114,7 +114,6 @@ This section introduces the certificate management notification API which is fur
 ##### 2.1.1.1 Company Certificate Request
 
 The Certificate Consumer is requesting a specific certificate from the Certificate Provider.
-This request can be sent by the Certificate Consumer continuously, for updates on the request state on Certificate Provider side.
 
 ![alt text](images/state-machine-certificate-distributor.svg "Certificate Request API State Machine")
 

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -27,7 +27,7 @@ This standard is relevant to the following parties:
 
 ## COMPARISON WITH THE PREVIOUS VERSION OF THE STANDARD
 
-The updated standard introduces several enhancements over the previous version. One of the key changes is the definition of an OpenAPI. This will allow companies to proactively request certificates and provide feedback on their status. For the notification's requests, the Industry Core Standard (CX-0151 Industry Core: Basics v.1.0.0) has been adopted.
+The updated standard introduces several enhancements over the previous version. One of the key changes is the definition of an OpenAPI. This will allow companies to proactively request certificates and provide feedback on their status. For the notification's requests, the Industry Core Standard ([CX-0151:1.0.0 Industry Core: Basics](https://catenax-ev.github.io/docs/standards/CX-0151-IndustryCoreBasics)) has been adopted.
 
 Another important update involves a correction to the data model. The enclosedSiteBpn trait now accurately supports both BPNS and BPNA values, resolving a previous issue.
 Resolved an issue in the usage policy.
@@ -42,7 +42,7 @@ The following company certificate use cases are supported in this release:
 
 1. Certificate Provider wants to publish a certificate / Certificate Consumer wants to discover a published certificate.
 2. Certificate Consumer wants to request a certificate from a specific Certificate Provider
-3. Certificate Consumer wants to notify a Certificate Provider of acceptance or rejection of a certificate published in #1 via a feedback message
+3. Certificate Consumer wants to notify a Certificate Provider of acceptance or rejection of a consumed certificate via a status message
 4. Certificate Provider wants to notify a Certificate Consumer of the availability of a new certificate asset
 
 For avoidance of the doubt, we are not replacing the existing publication semantic model.
@@ -97,9 +97,9 @@ Use cases to provide certificates (from who initiates communication, negotiation
 - Certificate Consumer -> Certificate Provider: Company Certificate Pull
 - Certificate Provider -> Certificate Consumer: Company Certificate Push
 
-Use case to give feedback for provided certificates:
+Use case to give feedback on the status for consumed certificates:
 
-- Certificate Consumer -> Certificate Provider: Company Certificate Status (Accepted, Rejected or Received)
+- Certificate Consumer -> Certificate Provider: Company Certificate Status (Received, Accepted, or Rejected)
 
 Use case to notify about availability of certificates:
 
@@ -159,7 +159,6 @@ This request can be sent by the Certificate Consumer continuously, for updates o
 The detailed response bodies for HTTP Code 200 are described in 2.1.1.1.2 and following.
 HTTP Status Codes 202, 400 and 500 do not come with a response body.
 
-
 ##### 2.1.1.1.2 HTTP Response Body for HTTP Code 200, Status: IN PROGRESS
 
 Case: Certificate Request Still In Process
@@ -182,7 +181,7 @@ Case: Certificate Request Still In Process
 
 ##### 2.1.1.1.3 HTTP Response Body for HTTP Code 200, Status: COMPLETED
 
-Finished Processing and Certificate Available in EDC.
+Finished Processing and Certificate available in EDC.
 The content body also provides the documentId of the certificate.
 This simplifies finding the correct offer for the requested certificate.
 
@@ -252,7 +251,7 @@ The error message is free text.
 
 Certificate is pushed by the Certificate Provider to the Certificate Consumer.
 The enclosed BPNs can be a mix of sites and addresses.
-The Certificate Consumer may want to send a subsequent feedback message.
+The Certificate Consumer may want to send a subsequent status message.
 
 `POST /companycertificate/push`
 
@@ -301,28 +300,29 @@ The Certificate Consumer may want to send a subsequent feedback message.
     }
   }
 }
+
 ```
-The ´senderFeedbackUrl´ specifies, where the Certificate Provider expects the feedback of the Certificate Consumer.
+The ´senderFeedbackUrl´ specifies, where the Certificate Provider expects feedback on the status from the Certificate Consumer.
 The expected value **MUST** be a concrete path to the version 1 dataspace protocol endpoint,
 where a data offer for an asset of type cx-taxo:CCMAPI **MUST** be available for the Certificate Consumer.
 
 >**Push header `senderFeedbackUrl` explanation**:
->This information is intended as a temporary solution to support the unique identification of multiple feedback endpoints across multiple EDCs belonging to one legal entity. 
+>This information is intended as a temporary solution to support the unique identification of multiple status endpoints across multiple EDCs belonging to one legal entity.
 >The typical way to implement such differentiation in the Catena-X data space would be to provide additional, distinguishing attributes to the EDC assets to enable an automated search mechanism via the EDC discovery service and EDC catalogs. 
 >Since the current changes are implemented as a non-breaking standard patch, the senderFeedbackUrl remains an intermediate solution. 
 >A future change is required in that regard, especially when considering the deprecation of the v1 DSP endpoint in favor of an upcoming EDC `.well-known` endpoint that supports multiple DSP versions.
 
->**DocumentID spelling**:
-> Please mind that in contrast to other requests the field `documentID` in the push notification request is spelled with a capital `D`.
+>**`documentID` spelling**:
+> Please mind that in contrast to other requests the field `documentID` in the push notification request is spelled with a capital `D` due to the spelling in the [aspect model](#31-aspect-model-businesspartnercertificate).
 
-##### 2.1.1.3 Company Certificate Feedback
+##### 2.1.1.3 Company Certificate Status
 
-`POST /companycertificate/feedback`
+`POST /companycertificate/status`
 
-This API is used by the Certificate Consumer to give a feedback to the Certificate Provider, thus either accepting or rejecting the provided certificate.
-This is regardless of whether the certificate was [pulled](#2111-company-certificate-request) or [pushed](#2112-company-certificate-push).
+This API is used by the Certificate Consumer to give feedback on the status to the Certificate Provider, thus either accepting or rejecting the provided certificate.
+This is regardless of whether the certificate was [pulled](#2152-pull-mechanism) or [pushed](#2151-push-mechanism).
 
-##### 2.1.1.3.1 Company Certificate Feedback: Received
+##### 2.1.1.3.1 Company Certificate Status: Received
 
 Certificate has been received by Certificate Consumer and validation is in progress.
 
@@ -330,7 +330,7 @@ Certificate has been received by Certificate Consumer and validation is in progr
 {
   "header": {
     "senderBpn": "BPNL0000000001AB",
-    "context": "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
+    "context": "CompanyCertificateManagement-CCMAPI-Status:1.0.0",
     "messageId": "f2cd0df7-5cdb-4a09-b273-c7cfbceccf2d",
     "receiverBpn": "BPNL0000000002CD",
     "sentDateTime": "2025-05-04T00:00:00-07:00",
@@ -351,7 +351,7 @@ Certificate has been received by Certificate Consumer and validation is in progr
 }
 ```
 
-##### 2.1.1.3.2 Company Certificate Feedback: Accepted
+##### 2.1.1.3.2 Company Certificate Status: Accepted
 
 Certificate is accepted. 
 The documentId **MUST** match the documentId that was communicated by the certificate provider.
@@ -361,7 +361,7 @@ The `locationBpns` can be a mix of sites and addresses.
 {
   "header": {
     "senderBpn": "BPNL0000000001AB",
-    "context": "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
+    "context": "CompanyCertificateManagement-CCMAPI-Status:1.0.0",
     "messageId": "a6dca795-a1ae-4e8d-9e41-b82ebe9ebd5b",
     "receiverBpn": "BPNL0000000002CD",
     "sentDateTime": "2025-05-04T00:00:00-07:00",
@@ -382,15 +382,15 @@ The `locationBpns` can be a mix of sites and addresses.
 }
 ```
 
-##### 2.1.1.3.3 Company Certificate Feedback: Rejected
+##### 2.1.1.3.3 Company Certificate Status: Rejected
 
-Certificate is rejected by Certificate Consumer with one or multiple reasons.
+Certificate is rejected by the Certificate Consumer with one or multiple reasons.
 
 ```json
 {
   "header": {
     "senderBpn": "BPNL0000000001AB",
-    "context": "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0",
+    "context": "CompanyCertificateManagement-CCMAPI-Status:1.0.0",
     "messageId": "f67b9853-b714-4427-a8f3-4c53a9822da0",
     "receiverBpn": "BPNL0000000002CD",
     "sentDateTime": "2025-05-04T00:00:00-07:00",
@@ -452,10 +452,10 @@ Certificate is rejected by Certificate Consumer with one or multiple reasons.
 }
 ```
 
-##### 2.1.1.3 Company Certificate Available
+##### 2.1.1.4 Company Certificate Available
 
 The Certificate Consumer is notified that a certificate is available.
-The Certificate Consumer may want to get the certificate via the pull mechanism.
+The Certificate Consumer may want to consume the certificate via the pull mechanism.
 
 ```json
 {
@@ -501,7 +501,7 @@ The following sections detail how notification API and certificate assets should
 Please note the depicted examples show `@id` fields with random example UUIDs.
 Every dataspace participant may use their individual random uuid.
 
-##### 2.1.4.1  Notification API
+##### 2.1.4.1 Notification API
 
 > *This section is normative*
 
@@ -512,26 +512,24 @@ In turn, the Certificate Consumer **MAY** offer an asset to expose an API for th
 
 The property [[type]](http://purl.org/dc/terms/type) **MUST** reference the name of the certificate management API as defined in the Catena-X taxonomy published under [[taxonomy]](https://w3id.org/catenax/taxonomy).
 
-| **Type**       | **Subject**                               | **Version** | **Description**                                                                                                                                                                                                                                |
-|----------------|-------------------------------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| cx-taxo:CCMAPI | cx-taxo:CompanyCertificateNotificationApi | 3.0         | Offers *Certificate Notification API* for [requesting](#2111-company-certificate-request) and [pushing](#2112-company-certificate-push) certificates as well as send [feedback](#2113-company-certificate-feedback) for provided certificates. |
-
+| **Type**       | **Subject**                                         | **Version** | **Description** |
+|----------------|-----------------------------------------------------|-------------|-----------------|
+| cx-taxo:CCMAPI | cx-taxo:CompanyCertificateManagementNotificationApi | 3.0         | Offers *Certificate Notification API* for [requesting](#2111-company-certificate-request) and [pushing](#2112-company-certificate-push) certificates as well as sending feedback on the [status](#2113-company-certificate-status) for provided certificates and receiving [availability](#2114-company-certificate-available) notifications. |
 
 There **MUST** only be one unique asset per API (subject and version) across all connectors of one BPNL.
 
 *Example*: it is possible to have these assets available next to one-another:
-- ```{"dct:subject"."@id": "cx-taxo:CompanyCertificateNotificationApi", "cx-common:version": "3.0"}```, and 
-- ```{"dct:subject"."@id": "cx-taxo:CompanyCertificateNotificationApi", "cx-common:version": "2.0"}```
+- ```{ "dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementNotificationApi" }, "cx-common:version": "3.0" }```, 
+- ```{ "dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementNotificationApi" }, "cx-common:version": "2.0" }```
 
 since they either differ in the value of the version or the subject. 
 But it would not be possible to have two of the same subject and the same version.
 
 *Example that is not allowed:*
-- ```{"dct:subject"."@id": "cx-taxo:CompanyCertificateNotificationApi", "cx-common:version": "3.0"}```
-- ```{"dct:subject"."@id": "cx-taxo:CompanyCertificateNotificationApi", "cx-common:version": "3.0"}```
+- ```{"dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementNotificationApi" }, "cx-common:version": "3.0" }```,
+- ```{"dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementNotificationApi" }, "cx-common:version": "3.0" }```
 
 It doesn't matter if the assets are offered in one or in different connectors, as long as they belong to the same BPNL this is not allowed.
-
 
 **Example Certificate Notification API**
 ```json
@@ -543,9 +541,9 @@ It doesn't matter if the assets are offered in one or in different connectors, a
       "@id": "cx-taxo:CCMAPI"
     },
     "dct:subject": {
-      "@id": "cx-taxo:CompanyCertificateNotificationApi"
+      "@id": "cx-taxo:CompanyCertificateManagementNotificationApi"
     },
-    "dct:description": "Offers API for requesting and pushing certificates as well as sending feedback for provided certificates and receiving availability notifications.",
+    "dct:description": "Offers Certificate Notification API for requesting and pushing certificates as well as sending feedback on the status for provided certificates and receiving availability notifications.",
     "cx-common:version": "3.0"
   },
   "dataAddress": {},
@@ -557,17 +555,16 @@ It doesn't matter if the assets are offered in one or in different connectors, a
 }
 ```
 
-
 > The **API assets** are identified by the combination of `dct:subject` and `cx-common:version`.
 > When searching the EDC catalog for a specific API, make use of those properties in the catalog filter.
 
-##### 2.1.4.2  Certificates
+##### 2.1.4.2 Certificates
 
 The certificate assets **MUST** be created by the Certificate Provider in their connector catalog to be consumed by the Certificate Consumer.
 The property certificateType **MUST** reference the type of the certificate as defined in [3.2.2 Certificate Type](#322-certificate-type).
 The property enclosedSites **MUST** contain all BPNSs for which the certificate is valid.
-The subject **MUST** reference cx-taxo:CompanyCertificate.
-Additionally, the assets **MUST** contain the type ```cx-taxo:Submodel``` and the semanticId specified in [3.1.2 Business Partner Company Certificate Submodel](#312-business-partner-company-certificate-submodel).
+The subject **MUST** reference `cx-taxo:CompanyCertificate`.
+Additionally, the assets **MUST** contain the type `cx-taxo:Submodel` and the semanticId specified in [3.1.2 Business Partner Company Certificate Submodel](#312-business-partner-company-certificate-submodel).
 
 **Example Certificate EDC Asset:**
 
@@ -627,19 +624,20 @@ Additionally, the assets **MUST** contain the type ```cx-taxo:Submodel``` and th
 Certificate Provider & Certificate Consumer:
 - Certificate Provider **MUST** support at least one of the certificate provision mechanisms (push and/or pull mechanism)
 - Certificate Provider **MUST** expose company certificates in their catalog when using the pull mechanism.
-- Certificate Provider **MUST** set the correct access policy on the certificate offer to allow consumption by Consumer(s) when using the pull mechanism.
+- Certificate Provider **MUST** set the correct access and usage policy on the certificate offer to allow consumption by Consumer(s) when using the pull mechanism.
 
-- Certificate Consumer **MAY** implement the [push endpoint](#2112-company-certificate-push) for the Certificate Provider to push certificates to, but **MUST** set the correct access policy on the offer, when choosing to do so.
-- Certificate Consumer **MAY** send a certificate request via POST /companycertificate/request which **MUST** be replied to by the Certificate Provider according to the endpoint definitions.
-- Certificate Consumer **MAY** send a notification of acceptance or rejection via POST /companycertificate/feedback.
+- Certificate Consumer **MAY** implement the [push endpoint](#2112-company-certificate-push) for the Certificate Provider to push certificates to, but **MUST** set the correct access and usage policy on the offer, when choosing to do so.
+- Certificate Consumer **MAY** send a certificate request via `POST /companycertificate/request` which **MUST** be replied to by the Certificate Provider according to the endpoint definitions.
+- Certificate Consumer **MAY** send a notification of reception when the certificate validation has started via `POST /companycertificate/status`.
+- Certificate Consumer **MAY** send a notification of acceptance or rejection via `POST /companycertificate/status`.
   Certificate Provider **MUST** respond according to the [error handling](#212-error-handling).
 
-- Certificate Provider **MAY** send a notification of availability via POST /companycertificate/available after the referenced company certificate is exposed in their catalog.
+- Certificate Provider **MAY** send a notification of availability via `POST /companycertificate/available` after the referenced company certificate is exposed in their catalog.
   Certificate Consumer **MUST** respond according to the [error handling](#212-error-handling) and **SHOULD** get the new certificate via the pull mechanism.
-- Certificate Consumer **MAY** implement the [available endpoint](#2113-company-certificate-available) for the Certificate Provider to send availability notifications to, but **MUST** set the correct access policy on the offer, when choosing to do so.
+- Certificate Consumer **MAY** implement the [available endpoint](#2113-company-certificate-available) for the Certificate Provider to send availability notifications to, but **MUST** set the correct access and usage policy on the offer, when choosing to do so.
 
 Business Application Provider:
-- Business Application Provider **MUST** implement all features of the Certificate Notification API, including the support of the push, the pull and also the feedback mechanism.
+- Business Application Provider **MUST** implement all features of the Certificate Notification API, including the support of the push, the pull and also the status and available mechanism.
 - Business Application Provider **MUST** offer the push mechanism option to the Certificate Consumer application user, if the Certificate Consumer supports the push mechanism.
 
 ##### 2.1.5.1 PUSH Mechanism
@@ -648,7 +646,7 @@ Business Application Provider:
 
 The Certificate PUSH Diagram describes the secure transmission of certificates from a Backend Certificate Provider to a Backend Certificate Consumer via EDC (Eclipse Data Connector) components.
 The process starts with a contract agreement for a Notification Asset, followed by the provider pushing the certificate to the provided endpoint in the asset.  
-The certificate is then processed by the Backend Certificate Consumer, which finalizes the workflow by generating a feedback message which is pushed to the provider.
+The certificate is then processed by the Backend Certificate Consumer, which finalizes the workflow by generating a status message which is pushed to the provider.
 
 ##### 2.1.5.2 PULL Mechanism
 
@@ -658,17 +656,17 @@ The Certificate PULL Diagram describes the process of Consumer retrieving a cert
 It begins with the provider creating a Certificate Asset with corresponding contract definition in the EDC Catalog. 
 The Consumer searches the catalog using specific filters, initiates a contract negotiation, and retrieves the Endpoint Data Reference (EDR). 
 The Data Plane then facilitates secure data transfer, allowing the consumer to pull the certificate. 
-Once retrieved, the Backend Certificate Consumer processes the certificate and sends a Feedback Message to confirm the status.
+Once retrieved, the Backend Certificate Consumer processes the certificate and sends a status message to confirm the status.
 
 ##### 2.1.5.3 AVAILABLE notification followed by PULL mechanism
 
-After the Certificate Provider has created a Certificate Asset with corresponding contract definition in the EDC Catalog, the Certificate Provider sends a Certificate Available Notification to the Certificate Consumer.
+After the Certificate Provider has created a Certificate Asset with the corresponding contract definition in the EDC Catalog, the Certificate Provider sends a Certificate Available Notification to the Certificate Consumer.
 The Certificate Consumer uses the above described PULL mechanism to get the certificate data.
 This reduces the Certificate Consumers need for active checks for missing certificates or certificate updates and enables access to the latest certificate data.
 
 ##### 2.1.6 Usage Policy
 
-All assets included in the EDC of a dataspace participant (APIs and Certificates) **MUST** contain a usage policy that includes the Catena-X Data Exchange Governance document in version 1.0.
+All offers included in the EDC of a dataspace participant (APIs and Certificates) **MUST** contain a usage policy that includes the Catena-X Data Exchange Governance document in version 1.0.
 The use-case introduces the following usage purpose:
 
 - **`cx.ccm.base:1:`** *The exchanged business partner certificates are used for the purpose of verification and validation of the existence of a certification.*
@@ -744,7 +742,7 @@ The semantic model has the unique identifier
 
 > urn:samm:io.catenax.business_partner_certificate:3.1.0
 
-This identifier **MUST** be used by the data provider to define the semantics of the data being transferred.
+This identifier **MUST** be used by the Certificate Provider to define the semantics of the data being transferred.
 
 #### 3.1.3 FORMATS OF SEMANTIC MODEL
 

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -722,12 +722,14 @@ Applying these rules to the supported list of certificate types leads to the fol
 | ISO 14001     | iso14001    |
 | ISO 9001      | iso9001     |
 | ISO 45001     | iso45001    |
+| OHSAS 18001   | ohsas18001  |
 | ISO/IEC 27001 | isoiec27001 |
 | ISO 50001     | iso50001    |
 | ISO/IEC 17025 | isoiec17025 |
 | ISO 20000     | iso20000    |
 | ISO 22301     | iso22301    |
 | AEO           | aeo         |
+| CTPAT         | ctpat       |
 | VDA6.4        | vda64       |
 
 

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -131,7 +131,7 @@ This request can be sent by the Certificate Consumer continuously, for updates o
   },
   "content": {
     "certifiedBpn": "BPNL00000003AYRE",
-    "certificateType": "ISO9001",
+    "certificateType": "iso9001",
     "locationBpns": [
       "BPNA000000000001",
       "BPNA000000000002",
@@ -586,7 +586,7 @@ Additionally, the assets **MUST** contain the type ```cx-taxo:Submodel``` and th
       "@id": "urn:samm:io.catenax.business_partner_certificate:3.1.0#BusinessPartnerCertificate"
     },
     "dct:certificateType": {
-      "@id": "cx-taxo:ISO9001"
+      "@id": "cx-taxo:iso9001"
     },
     "dct:enclosedSites": [
       {

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -787,7 +787,7 @@ The internal reference id to request a certificate document.
 
 - [CX-0003:1.1 SAMM Aspect Meta Model](https://catenax-ev.github.io/docs/standards/CX-0003-SAMMSemanticAspectMetaModel)
 - [CX-0010:2.0 Business Partner Number](https://catenax-ev.github.io/docs/standards/CX-0010-BusinessPartnerNumber)
-- CX-0151 Industry Core: Basics v.1.0.0
+- [CX-0151:1.0.0 Industry Core: Basics](https://catenax-ev.github.io/docs/standards/CX-0151-IndustryCoreBasics)
 
 ### 4.2 NON-NORMATIVE REFERENCES
 

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -112,7 +112,8 @@ This section introduces the certificate management notification API which is fur
 #### 2.1.1 API endpoints and resources
 
 > [!WARNING]
-> **`senderFeedbackUrl` explanation**:
+> **`senderFeedbackUrl` explanation**
+>
 > This information is intended as a temporary solution to support the unique identification of multiple endpoints across multiple EDCs belonging to one legal entity.
 > The typical way to implement such differentiation in the Catena-X data space would be to provide additional,distinguishing attributes to the EDC assets to enable an automated search mechanism via the EDC discovery service and EDC catalogs.
 > Since the current changes are implemented as a non-breaking standard patch, the `senderFeedbackUrl` remains an intermediate solution.
@@ -121,6 +122,7 @@ This section introduces the certificate management notification API which is fur
 
 > [!CAUTION]
 > **`documentId` explanation**
+>
 > The `documentId` in the payloads of the Request, Feedback, and Available notifications does not refer to the `documentID` of the certificate.
 > Instead, it references the unique ID of the EDC asset of the certificate.
 > This is different for the Push notification, where the certificate itself is in the payload and therefore the `documentID` of the certificate is referenced.
@@ -326,6 +328,7 @@ where a data offer for an asset of type cx-taxo:CCMAPI **MUST** be available for
 
 > [!NOTE]
 > **`documentID` spelling**
+>
 > Please note that in contrast to other requests, the field `documentID` in the push notification request is spelled with a capital `D` due to the spelling in the [aspect model](#31-aspect-model-businesspartnercertificate)
 > and refers to the ID of the document of the certificate, not the unique ID of the EDC asset of the certificate.
 

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -122,11 +122,12 @@ The Certificate Consumer is requesting a specific certificate from the Certifica
 ```json
 {
   "header": {
-    "senderBpn": "BPNL0000000001AB",
+    "messageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "context": "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
-    "messageId": "e94eaa84-6fb3-4693-a189-201a20dfcecf",
+    "sentDateTime": "2024-10-07T10:15:00Z",
+    "senderBpn": "BPNL0000000001AB",
     "receiverBpn": "BPNL0000000002CD",
-    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "relatedMessageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "version": "3.1.0"
   },
   "content": {
@@ -165,11 +166,12 @@ Case: Certificate Request Still In Process
 ```json
 {
   "header": {
-    "senderBpn": "BPNL0000000001AB",
+    "messageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "context": "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
-    "messageId": "b53a4682-6cb5-48f3-b3fa-0bf20718dc52",
+    "sentDateTime": "2024-10-07T10:15:00Z",
+    "senderBpn": "BPNL0000000001AB",
     "receiverBpn": "BPNL0000000002CD",
-    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "relatedMessageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "version": "3.1.0"
   },
   "content": {
@@ -187,11 +189,12 @@ This simplifies finding the correct offer for the requested certificate.
 ```json
 {
   "header": {
-    "senderBpn": "BPNL0000000001AB",
+    "messageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "context": "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
-    "messageId": "07a71867-f05e-4b6a-9944-2531b854c40a",
+    "sentDateTime": "2024-10-07T10:15:00Z",
+    "senderBpn": "BPNL0000000001AB",
     "receiverBpn": "BPNL0000000002CD",
-    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "relatedMessageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "version": "3.1.0"
   },
   "content": {
@@ -215,11 +218,12 @@ The error message is free text.
 ```json
 {
   "header": {
-    "senderBpn": "BPNL0000000001AB",
+    "messageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "context": "CompanyCertificateManagement-CCMAPI-Request:1.0.0",
-    "messageId": "0ee9c20f-a55e-43c9-9a3f-0cb23d4f134d",
+    "sentDateTime": "2024-10-07T10:15:00Z",
+    "senderBpn": "BPNL0000000001AB",
     "receiverBpn": "BPNL0000000002CD",
-    "sentDateTime": "2025-05-04T00:00:00-07:00",
+    "relatedMessageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "version": "3.1.0"
   },
   "content": {
@@ -257,13 +261,14 @@ The Certificate Consumer may want to send a subsequent status message.
 ```json
 {
   "header": {
-    "senderBpn": "BPNL0000000001AB",
-    "senderFeedbackUrl": "https://domain.tld/path/to/edc/api/v1/dsp",
+    "messageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "context": "CompanyCertificateManagement-CCMAPI-Push:1.0.0",
-    "messageId": "8bf22334-97f2-42b4-afca-f68160707b83 ",
+    "sentDateTime": "2024-10-07T10:15:00Z",
+    "senderBpn": "BPNL0000000001AB",
     "receiverBpn": "BPNL0000000002CD",
-    "sentDateTime": "2025-05-04T00:00:00-07:00",
-    "version": "3.1.0"
+    "relatedMessageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
+    "version": "3.1.0",
+    "senderFeedbackUrl": "https://domain.tld/path/to/edc/api/v1/dsp"
   },
   "content": {
     "businessPartnerNumber": "BPNL0000000001AB",
@@ -299,7 +304,6 @@ The Certificate Consumer may want to send a subsequent status message.
     }
   }
 }
-
 ```
 
 The ´senderFeedbackUrl´ specifies, where the Certificate Provider expects feedback on the status from the Certificate Consumer.
@@ -329,12 +333,14 @@ Certificate has been received by Certificate Consumer and validation is in progr
 ```json
 {
   "header": {
-    "senderBpn": "BPNL0000000001AB",
+    "messageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "context": "CompanyCertificateManagement-CCMAPI-Status:1.0.0",
-    "messageId": "f2cd0df7-5cdb-4a09-b273-c7cfbceccf2d",
+    "sentDateTime": "2024-10-07T10:15:00Z",
+    "senderBpn": "BPNL0000000001AB",
     "receiverBpn": "BPNL0000000002CD",
-    "sentDateTime": "2025-05-04T00:00:00-07:00",
-    "version": "3.1.0"
+    "relatedMessageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
+    "version": "3.1.0",
+    "senderFeedbackUrl": "https://domain.tld/path/to/edc/api/v1/dsp"
   },
   "content": {
     "documentId": "00000000-0000-0000-0000-000000000002",
@@ -360,12 +366,14 @@ The `locationBpns` can be a mix of sites and addresses.
 ```json
 {
   "header": {
-    "senderBpn": "BPNL0000000001AB",
+    "messageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "context": "CompanyCertificateManagement-CCMAPI-Status:1.0.0",
-    "messageId": "a6dca795-a1ae-4e8d-9e41-b82ebe9ebd5b",
+    "sentDateTime": "2024-10-07T10:15:00Z",
+    "senderBpn": "BPNL0000000001AB",
     "receiverBpn": "BPNL0000000002CD",
-    "sentDateTime": "2025-05-04T00:00:00-07:00",
-    "version": "3.1.0"
+    "relatedMessageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
+    "version": "3.1.0",
+    "senderFeedbackUrl": "https://domain.tld/path/to/edc/api/v1/dsp"
   },
   "content": {
     "documentId": "00000000-0000-0000-0000-000000000001",
@@ -389,12 +397,14 @@ Certificate is rejected by the Certificate Consumer with one or multiple reasons
 ```json
 {
   "header": {
-    "senderBpn": "BPNL0000000001AB",
+    "messageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "context": "CompanyCertificateManagement-CCMAPI-Status:1.0.0",
-    "messageId": "f67b9853-b714-4427-a8f3-4c53a9822da0",
+    "sentDateTime": "2024-10-07T10:15:00Z",
+    "senderBpn": "BPNL0000000001AB",
     "receiverBpn": "BPNL0000000002CD",
-    "sentDateTime": "2025-05-04T00:00:00-07:00",
-    "version": "3.1.0"
+    "relatedMessageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
+    "version": "3.1.0",
+    "senderFeedbackUrl": "https://domain.tld/path/to/edc/api/v1/dsp"
   },
   "content": {
     "documentId": "00000000-0000-0000-0000-000000000003",
@@ -460,12 +470,14 @@ The Certificate Consumer may want to consume the certificate via the pull mechan
 ```json
 {
   "header": {
-    "senderBpn": "BPNL0000000001AB",
+    "messageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
     "context": "CompanyCertificateManagement-CCMAPI-Available:1.0.0",
-    "messageId": "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9",
+    "sentDateTime": "2024-10-07T10:15:00Z",
+    "senderBpn": "BPNL0000000001AB",
     "receiverBpn": "BPNL0000000002CD",
-    "sentDateTime": "2025-05-04T00:00:00-07:00",
-    "version": "3.1.0"
+    "relatedMessageId": "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72",
+    "version": "3.1.0",
+    "senderFeedbackUrl": "https://domain.tld/path/to/edc/api/v1/dsp"
   },
   "content": {
     "documentId": "00000000-0000-0000-0000-000000000001",
@@ -549,7 +561,15 @@ It doesn't matter if the assets are offered in one or in different connectors, a
     "dct:description": "Offers Certificate Notification API for requesting and pushing certificates as well as sending feedback on the status for provided certificates and receiving availability notifications.",
     "cx-common:version": "3.0"
   },
-  "dataAddress": {},
+  "dataAddress": {
+      "@type": "DataAddress",
+      "type": "HttpData",
+      "baseUrl": "https://backend-base-url/certificate-notification-api-base-path",
+      "proxyQueryParams": "false",
+      "proxyPath": "true",
+      "proxyMethod": "false",
+      "proxyBody": "true"
+    },
   "@context": {
     "dct": "http://purl.org/dc/terms/",
     "cx-taxo": "https://w3id.org/catenax/taxonomy#",

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -111,8 +111,8 @@ This section introduces the certificate management notification API which is fur
 
 #### 2.1.1 API endpoints and resources
 
-> [!WARNING] 
-> ** `senderFeedbackUrl` explanation**:
+> [!WARNING]
+> **`senderFeedbackUrl` explanation**:
 > This information is intended as a temporary solution to support the unique identification of multiple endpoints across multiple EDCs belonging to one legal entity.
 > The typical way to implement such differentiation in the Catena-X data space would be to provide additional,distinguishing attributes to the EDC assets to enable an automated search mechanism via the EDC discovery service and EDC catalogs.
 > Since the current changes are implemented as a non-breaking standard patch, the `senderFeedbackUrl` remains an intermediate solution.

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -42,7 +42,7 @@ The following company certificate use cases are supported in this release:
 
 1. Certificate Provider wants to publish a certificate / Certificate Consumer wants to discover a published certificate.
 2. Certificate Consumer wants to request a certificate from a specific Certificate Provider
-3. Certificate Consumer wants to notify a Certificate Provider of acceptance or rejection of a consumed certificate via a status message
+3. Certificate Consumer wants to notify a Certificate Provider of acceptance or rejection of a consumed certificate via a feedback message
 4. Certificate Provider wants to notify a Certificate Consumer of the availability of a new certificate asset
 
 For avoidance of the doubt, we are not replacing the existing publication semantic model.
@@ -90,7 +90,7 @@ See [API Message Flow](#215-message-flow-expectations) expectations for conforma
 
 > *This section and all its subsections are normative*
 
-Today, Certificate Consumer do not have a way to request certificates from a Certificate Provider. Also, Data Certificate Provider have no visibility on the status of a published certificate beyond the technical delivery. Finally, Certificate Provider do not have a standard mechanism to send new certificates to the Certificate Consumer when they become available.
+Today, Certificate Consumer do not have a way to request certificates from a Certificate Provider. Also, Data Certificate Provider have no visibility on the feedback of a published certificate beyond the technical delivery. Finally, Certificate Provider do not have a standard mechanism to send new certificates to the Certificate Consumer when they become available.
 
 Use cases to provide certificates (from who initiates communication, negotiation and data transfer):
 
@@ -99,7 +99,7 @@ Use cases to provide certificates (from who initiates communication, negotiation
 
 Use case to give feedback on the status for consumed certificates:
 
-- Certificate Consumer -> Certificate Provider: Company Certificate Status (Received, Accepted, or Rejected)
+- Certificate Consumer -> Certificate Provider: Company Certificate Feedback (Received, Accepted, or Rejected)
 
 Use case to notify about availability of certificates:
 
@@ -254,7 +254,7 @@ The error message is free text.
 
 Certificate is pushed by the Certificate Provider to the Certificate Consumer.
 The enclosed BPNs can be a mix of sites and addresses.
-The Certificate Consumer may want to send a subsequent status message.
+The Certificate Consumer may want to send a subsequent feedback message.
 
 `POST /companycertificate/push`
 
@@ -311,7 +311,7 @@ The expected value **MUST** be a concrete path to the version 1 dataspace protoc
 where a data offer for an asset of type cx-taxo:CCMAPI **MUST** be available for the Certificate Consumer.
 
 >**Push header `senderFeedbackUrl` explanation**:
->This information is intended as a temporary solution to support the unique identification of multiple status endpoints across multiple EDCs belonging to one legal entity.
+>This information is intended as a temporary solution to support the unique identification of multiple endpoints across multiple EDCs belonging to one legal entity.
 >The typical way to implement such differentiation in the Catena-X data space would be to provide additional, distinguishing attributes to the EDC assets to enable an automated search mechanism via the EDC discovery service and EDC catalogs.
 >Since the current changes are implemented as a non-breaking standard patch, the senderFeedbackUrl remains an intermediate solution.
 >A future change is required in that regard, especially when considering the deprecation of the v1 DSP endpoint in favor of an upcoming EDC `.well-known` endpoint that supports multiple DSP versions.
@@ -319,14 +319,14 @@ where a data offer for an asset of type cx-taxo:CCMAPI **MUST** be available for
 >**`documentID` spelling**:
 > Please mind that in contrast to other requests the field `documentID` in the push notification request is spelled with a capital `D` due to the spelling in the [aspect model](#31-aspect-model-businesspartnercertificate).
 
-##### 2.1.1.3 Company Certificate Status
+##### 2.1.1.3 Company Certificate Feedback
 
 `POST /companycertificate/status`
 
 This API is used by the Certificate Consumer to give feedback on the status to the Certificate Provider, thus either accepting or rejecting the provided certificate.
 This is regardless of whether the certificate was [pulled](#2152-pull-mechanism) or [pushed](#2151-push-mechanism).
 
-##### 2.1.1.3.1 Company Certificate Status: Received
+##### 2.1.1.3.1 Company Certificate Feedback: Received
 
 Certificate has been received by Certificate Consumer and validation is in progress.
 
@@ -357,7 +357,7 @@ Certificate has been received by Certificate Consumer and validation is in progr
 }
 ```
 
-##### 2.1.1.3.2 Company Certificate Status: Accepted
+##### 2.1.1.3.2 Company Certificate Feedback: Accepted
 
 Certificate is accepted.
 The documentId **MUST** match the documentId that was communicated by the certificate provider.
@@ -390,7 +390,7 @@ The `locationBpns` can be a mix of sites and addresses.
 }
 ```
 
-##### 2.1.1.3.3 Company Certificate Status: Rejected
+##### 2.1.1.3.3 Company Certificate Feedback: Rejected
 
 Certificate is rejected by the Certificate Consumer with one or multiple reasons.
 
@@ -526,7 +526,7 @@ The property [[type]](http://purl.org/dc/terms/type) **MUST** reference the name
 
 | **Type**       | **Subject**                                         | **Version** | **Description** |
 |----------------|-----------------------------------------------------|-------------|-----------------|
-| cx-taxo:CCMAPI | cx-taxo:CompanyCertificateManagementNotificationApi | 3.0         | Offers *Certificate Notification API* for [requesting](#2111-company-certificate-request) and [pushing](#2112-company-certificate-push) certificates as well as sending feedback on the [status](#2113-company-certificate-status) for provided certificates and receiving [availability](#2114-company-certificate-available) notifications. |
+| cx-taxo:CCMAPI | cx-taxo:CompanyCertificateManagementNotificationApi | 3.0         | Offers *Certificate Notification API* for [requesting](#2111-company-certificate-request) and [pushing](#2112-company-certificate-push) certificates as well as sending [feedback](#2113-company-certificate-feedback) on the status for provided certificates and receiving [availability](#2114-company-certificate-available) notifications. |
 
 There **MUST** only be one unique asset per API (subject and version) across all connectors of one BPNL.
 
@@ -662,7 +662,7 @@ Certificate Provider & Certificate Consumer:
 
 Business Application Provider:
 
-- Business Application Provider **MUST** implement all features of the Certificate Notification API, including the support of the push, the pull and also the status and available mechanism.
+- Business Application Provider **MUST** implement all features of the Certificate Notification API, including the support of the push, the pull and also the feedback and available mechanism.
 - Business Application Provider **MUST** offer the push mechanism option to the Certificate Consumer application user, if the Certificate Consumer supports the push mechanism.
 
 ##### 2.1.5.1 PUSH Mechanism
@@ -671,7 +671,7 @@ Business Application Provider:
 
 The Certificate PUSH Diagram describes the secure transmission of certificates from a Backend Certificate Provider to a Backend Certificate Consumer via EDC (Eclipse Data Connector) components.
 The process starts with a contract agreement for a Notification Asset, followed by the provider pushing the certificate to the provided endpoint in the asset.
-The certificate is then processed by the Backend Certificate Consumer, which finalizes the workflow by generating a status message which is pushed to the provider.
+The certificate is then processed by the Backend Certificate Consumer, which finalizes the workflow by generating a feedback message which is pushed to the provider.
 
 ##### 2.1.5.2 PULL Mechanism
 
@@ -681,7 +681,7 @@ The Certificate PULL Diagram describes the process of Consumer retrieving a cert
 It begins with the provider creating a Certificate Asset with corresponding contract definition in the EDC Catalog.
 The Consumer searches the catalog using specific filters, initiates a contract negotiation, and retrieves the Endpoint Data Reference (EDR).
 The Data Plane then facilitates secure data transfer, allowing the consumer to pull the certificate.
-Once retrieved, the Backend Certificate Consumer processes the certificate and sends a status message to confirm the status.
+Once retrieved, the Backend Certificate Consumer processes the certificate and sends a feedback message to confirm the status.
 
 ##### 2.1.5.3 AVAILABLE notification followed by PULL mechanism
 

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -159,6 +159,10 @@ The Certificate Consumer is requesting a specific certificate from the Certifica
 }
 ```
 
+> **`locationBpns` explanation**:
+> When a certificate is requested for multiple locations specified in `locationBpns`, the returned certificate's `enclosedSites` attribute may not cover all requested locations.
+> However, it should include at least one of the specified locations.
+
 ##### 2.1.1.1.1 HTTP Response Codes
 
 | HTTP Code | Description                                                               |

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -3,7 +3,7 @@ tags:
   - CAT/Value Added Services
 ---
 
-# CX-0135 Business Partner Company Certificate Management v2.3.1
+# CX-0135 Business Partner Company Certificate Management v2.3.3
 
 ## ABSTRACT
 
@@ -30,6 +30,7 @@ This standard is relevant to the following parties:
 The updated standard introduces several enhancements over the previous version. One of the key changes is the definition of an OpenAPI. This will allow companies to proactively request certificates and provide feedback on their status. For the notification's requests, the Industry Core Standard ([CX-0151:1.0.0 Industry Core: Basics](https://catenax-ev.github.io/docs/standards/CX-0151-IndustryCoreBasics)) has been adopted.
 
 Another important update involves a correction to the data model. The enclosedSiteBpn trait now accurately supports both BPNS and BPNA values, resolving a previous issue.
+
 Resolved an issue in the usage policy.
 
 These enhancements are designed to improve functionality and user experience, making the standard more reliable, efficient, and user-friendly.
@@ -115,7 +116,7 @@ This section introduces the certificate management notification API which is fur
 > **`senderFeedbackUrl` explanation**
 >
 > This information is intended as a temporary solution to support the unique identification of multiple endpoints across multiple EDCs belonging to one legal entity.
-> The typical way to implement such differentiation in the Catena-X data space would be to provide additional,distinguishing attributes to the EDC assets to enable an automated search mechanism via the EDC discovery service and EDC catalogs.
+> The typical way to implement such differentiation in the Catena-X data space would be to provide additional, distinguishing attributes to the EDC assets to enable an automated search mechanism via the EDC discovery service and EDC catalogs.
 > Since the current changes are implemented as a non-breaking standard patch, the `senderFeedbackUrl` remains an intermediate solution.
 > A future change is required in that regard, especially when considering the deprecation of the v1 DSP endpoint in favor of an upcoming EDC `.well-known` endpoint that supports multiple DSP versions.
 > This attribute will be deprecated in future releases and it will no longer be possible to use it for specifying the endpoint to receive feedback on.
@@ -322,9 +323,9 @@ The Certificate Consumer may want to send a subsequent feedback message.
 }
 ```
 
-The ´senderFeedbackUrl´ specifies, where the Certificate Provider expects feedback on the status from the Certificate Consumer.
+The `senderFeedbackUrl` specifies, where the Certificate Provider expects feedback on the status from the Certificate Consumer.
 The expected value **MUST** be a concrete path to the version 1 dataspace protocol endpoint,
-where a data offer for an asset of type cx-taxo:CCMAPI **MUST** be available for the Certificate Consumer.
+where a data offer for an asset of type `cx-taxo:CCMAPI` **MUST** be available for the Certificate Consumer.
 
 > [!NOTE]
 > **`documentID` spelling**

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -3,7 +3,7 @@ tags:
   - CAT/Value Added Services
 ---
 
-# CX-0135 Business Partner Company Certificate Management v2.3.3
+# CX-0135 Business Partner Company Certificate Management v2.4.0
 
 ## ABSTRACT
 

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -19,11 +19,11 @@ This standard is relevant to the following parties:
 - Certificate Provider: Dataspace Participant who provides certificates.
 - Business Application Provider
 
->**Context regarding the naming of involved parties:**
->The Catena-X operating model, as well as the EDC, uses the terms `Data Consumer` and `Data Provider`.
->The EDC uses these terms in regard to the parties that offer and consume EDC assets, while the operating model uses them in the context of information flow.
->In some cases, these understandings align, but, for example, in the case of APIs (especially the certificate push mechanism), a mismatch can occur between the two.
->To avoid misunderstandings, we use the terms `Certificate Consumer` and `Certificate Provider` to explicitly prevent this ambiguity.
+> **Context regarding the naming of involved parties:**
+> The Catena-X operating model, as well as the EDC, uses the terms `Data Consumer` and `Data Provider`.
+> The EDC uses these terms in regard to the parties that offer and consume EDC assets, while the operating model uses them in the context of information flow.
+> In some cases, these understandings align, but, for example, in the case of APIs (especially the certificate push mechanism), a mismatch can occur between the two.
+> To avoid misunderstandings, we use the terms `Certificate Consumer` and `Certificate Provider` to explicitly prevent this ambiguity.
 
 ## COMPARISON WITH THE PREVIOUS VERSION OF THE STANDARD
 
@@ -111,6 +111,20 @@ This section introduces the certificate management notification API which is fur
 
 #### 2.1.1 API endpoints and resources
 
+> [!WARNING] 
+> ** `senderFeedbackUrl` explanation**:
+> This information is intended as a temporary solution to support the unique identification of multiple endpoints across multiple EDCs belonging to one legal entity.
+> The typical way to implement such differentiation in the Catena-X data space would be to provide additional,distinguishing attributes to the EDC assets to enable an automated search mechanism via the EDC discovery service and EDC catalogs.
+> Since the current changes are implemented as a non-breaking standard patch, the `senderFeedbackUrl` remains an intermediate solution.
+> A future change is required in that regard, especially when considering the deprecation of the v1 DSP endpoint in favor of an upcoming EDC `.well-known` endpoint that supports multiple DSP versions.
+> This attribute will be deprecated in future releases and it will no longer be possible to use it for specifying the endpoint to receive feedback on.
+
+> [!CAUTION]
+> **`documentId` explanation**
+> The `documentId` in the payloads of the Request, Feedback, and Available notifications does not refer to the `documentID` of the certificate.
+> Instead, it references the unique ID of the EDC asset of the certificate.
+> This is different for the Push notification, where the certificate itself is in the payload and therefore the `documentID` of the certificate is referenced.
+
 ##### 2.1.1.1 Company Certificate Request
 
 The Certificate Consumer is requesting a specific certificate from the Certificate Provider.
@@ -151,10 +165,10 @@ The Certificate Consumer is requesting a specific certificate from the Certifica
 | 400       | Request malformed.                                                        |
 | 500       | Internal Server Error.                                                    |
 
->**EDC Behavior**:
->At the moment (standard release 25.09), the open-source EDC will always proxy a `500` internal server error when it encounters a `4xx` or `5xx` HTTP response code from the API.
->This means that in the case of a malformed request, while the API should return a `400` status code, the final EDC response that the consumer receives will be `500`.
->Until a future EDC update changes this behavior to proxy all status codes without changes, applications will need to be able to deal with this technical reality.
+> **EDC Behavior**:
+> At the moment (standard release 25.09), the open-source EDC will always proxy a `500` internal server error when it encounters a `4xx` or `5xx` HTTP response code from the API.
+> This means that in the case of a malformed request, while the API should return a `400` status code, the final EDC response that the consumer receives will be `500`.
+> Until a future EDC update changes this behavior to proxy all status codes without changes, applications will need to be able to deal with this technical reality.
 
 The detailed response bodies for HTTP Code 200 are described in 2.1.1.1.2 and following.
 HTTP Status Codes 202, 400 and 500 do not come with a response body.
@@ -204,7 +218,7 @@ This simplifies finding the correct offer for the requested certificate.
 }
 ```
 
->**`documentId` explanation**:
+> **`documentId` explanation**:
 > The reasoning why a documentId (the unique ID of EDC asset of the certificate) is to be returned (and not for example the certificate as a return payload) is,
 > so that the Certificate Provider can specify (for each certificate) a dedicated contract offer, and thus use different usage policies for the certificates and API(s).
 > That way the Certificate Provider has all options available in terms of data sovereignty and full access control on an EDC (contract based) level.
@@ -310,21 +324,21 @@ The ´senderFeedbackUrl´ specifies, where the Certificate Provider expects feed
 The expected value **MUST** be a concrete path to the version 1 dataspace protocol endpoint,
 where a data offer for an asset of type cx-taxo:CCMAPI **MUST** be available for the Certificate Consumer.
 
->**Push header `senderFeedbackUrl` explanation**:
->This information is intended as a temporary solution to support the unique identification of multiple endpoints across multiple EDCs belonging to one legal entity.
->The typical way to implement such differentiation in the Catena-X data space would be to provide additional, distinguishing attributes to the EDC assets to enable an automated search mechanism via the EDC discovery service and EDC catalogs.
->Since the current changes are implemented as a non-breaking standard patch, the senderFeedbackUrl remains an intermediate solution.
->A future change is required in that regard, especially when considering the deprecation of the v1 DSP endpoint in favor of an upcoming EDC `.well-known` endpoint that supports multiple DSP versions.
-
->**`documentID` spelling**:
-> Please mind that in contrast to other requests the field `documentID` in the push notification request is spelled with a capital `D` due to the spelling in the [aspect model](#31-aspect-model-businesspartnercertificate).
+> [!NOTE]
+> **`documentID` spelling**
+> Please note that in contrast to other requests, the field `documentID` in the push notification request is spelled with a capital `D` due to the spelling in the [aspect model](#31-aspect-model-businesspartnercertificate)
+> and refers to the ID of the document of the certificate, not the unique ID of the EDC asset of the certificate.
 
 ##### 2.1.1.3 Company Certificate Feedback
 
 `POST /companycertificate/status`
 
-This API is used by the Certificate Consumer to give feedback on the status to the Certificate Provider, thus either accepting or rejecting the provided certificate.
-This is regardless of whether the certificate was [pulled](#2152-pull-mechanism) or [pushed](#2151-push-mechanism).
+This API is used by the Certificate Consumer to provide feedback on the status to the Certificate Provider, either accepting or rejecting the provided certificate.
+This applies regardless of whether the certificate was [pulled](#2152-pull-mechanism) or [pushed](#2151-push-mechanism).
+
+If the certificate being given feedback on was consumed using the pull mechanism, the `documentId` in the payload must refer to the unique ID of the EDC asset of the certificate.
+
+When the push mechanism was used, the `relatedMessageId` must be set to the `messageId` of the push notification for which feedback is being provided.
 
 ##### 2.1.1.3.1 Company Certificate Feedback: Received
 
@@ -662,8 +676,8 @@ Certificate Provider & Certificate Consumer:
 
 Business Application Provider:
 
-- Business Application Provider **MUST** implement all features of the Certificate Notification API, including the support of the push, the pull and also the feedback and available mechanism.
-- Business Application Provider **MUST** offer the push mechanism option to the Certificate Consumer application user, if the Certificate Consumer supports the push mechanism.
+- Business Application Provider **MUST** implement all features of the Certificate Notification API, including the support of the push, the pull and also the feedback and the available mechanism.
+- Business Application Provider **MUST** offer the push mechanism option to the application user, if the Certificate Consumer supports the push mechanism.
 
 ##### 2.1.5.1 PUSH Mechanism
 

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -102,7 +102,7 @@ components:
             certifiedBpn:
               type: string
               description: The BPNL of the legal entity for which the requested certificate has been issued
-              pattern: "^BPNL[A-Z0-9]{12}$"
+              pattern: "^BPNL[a-zA-Z0-9]{12}$"
               examples:
                 - "BPNL0000000002CD"
             certificateType:
@@ -188,7 +188,7 @@ components:
     BpnLocation:
       type: string
       description: The BPNA or BPNS of either an address or site location
-      pattern: "^BPN[AS][A-Z0-9]{12}$"
+      pattern: "^BPN[AS][a-zA-Z0-9]{12}$"
       examples:
         - "BPNA000000000001"
         - "BPNS000000000002"

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -170,16 +170,6 @@ components:
           items:
             $ref: '#/components/schemas/LocationErrorCollection'
 
-
-    BpnlType:
-      type: string
-      description: "A business partner number for legal entities. The provided regular expression ensures that the BPNL is composed of prefix 'BPNL', 10 digits and two alphanumeric letters."
-      pattern: "^BPNL[A-Z0-9]{12}$"
-
-    BpnsType:
-      type: string
-      pattern: "^BPNS[A-Z0-9]{12}$"
-
     BpnLocation:
       type: string
       description: The BPNA or BPNS of either an address or site location
@@ -188,18 +178,6 @@ components:
         - "BPNA000000000001"
         - "BPNS000000000002"
 
-    CertificateType:
-      description: "Detailed entity of the certificate like IS09001:2015, IATF 16949:2015 or other, valid types are registered at BPN metadatacontroller"
-      type: object
-      required:
-        - certificateType
-      properties:
-        certificateType:
-          type: string
-          description: "Type of the certificate as defined on the document,valid types are registered at BPN metadatacontroller"
-        certificateVersion:
-          type: string
-          description: "Version of the certificate as defined on the document, usually the specific version of a certification standard"
 
 
     CertificatePush:
@@ -213,43 +191,6 @@ components:
         content:
           $ref: 'https://raw.githubusercontent.com/eclipse-tractusx/sldt-semantic-models/refs/heads/main/io.catenax.business_partner_certificate/3.1.0/gen/BusinessPartnerCertificate-schema.json'
 
-    DocumentContent:
-      description: Describe the certificate document content.
-      type: object
-      required:
-        - creationDate
-        - documentID
-        - contentType
-        - contentBase64
-      properties:
-        creationDate:
-          type: string
-          pattern: date-time
-          description: The creation date of the document.
-        documentID:
-          type: string
-          description: The id of the certificate document as stored by the data service provider.
-        contentType:
-          type: string
-          description: The MIME type of the document content.
-        contentBase64:
-          type: string
-          description: "The encoded data using the Base64 encoding scheme, which converts binary data into a string of ASCII characters. "
-
-
-    EnclosedSite:
-      description: "Entity representing an enclosed site, can be the Business Partner Number Site (BPNS) or Business Partner Number Address (BPNA)."
-      type: object
-      required:
-        - enclosedSiteBpn
-      properties:
-        enclosedSiteBpn:
-          description: The Business Partner Number (BPN) of an enclosed site
-          $ref: "#/components/schemas/BpnsType"
-        areaOfApplication:
-          type: string
-          description: Details on which areas / application types a certificate is valid for a company and/or site.
-
     Error:
       type: object
       required:
@@ -261,19 +202,6 @@ components:
           examples:
             - "We do not process certificates on Sunday"
             - "Can not provide certicate for requested locations"
-
-    Issuer:
-      description: Issuer name and the Business Partner Number (BPN).
-      type: object
-      required:
-        - issuerName
-      properties:
-        issuerName:
-          type: string
-          description: Name of the Issuer i.e. Certifying Authority.
-        issuerBpn:
-          description: The Business Partner Number (BPN) of the certificate issue.
-          $ref: "#/components/schemas/BpnlType"
 
     LocationErrorCollection:
       type: object
@@ -351,18 +279,6 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/BpnLocation'
-
-    TrustValidator:
-      description: The Business Partner Number (BPN) of the data service provider who validated the given certificate
-      type: object
-      properties:
-        validatorName:
-          type: string
-          description: The optional name of the data service provider who validated
-            the given certificate
-        validatorBpn:
-          description: The Business Partner Number (BPN) of the data service provider who validated the given certificate
-          $ref: "#/components/schemas/BpnlType"
 
   examples:
     CertificateRequestCompleted:

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -26,11 +26,13 @@ components:
           pattern: "^BPNL[a-zA-Z0-9]{12}$"
           type: string
           description: The Business Partner Number of the sending party
-          example: BPNL0000000001AB
+          examples:
+            - BPNL0000000001AB
         context:
           type: string
           description: The context defines the type of company certificate message
-          example: CompanyCertificateManagement-CCMAPI-Request:1.0.0
+          examples:
+            - CompanyCertificateManagement-CCMAPI-Request:1.0.0
           enum:
           - CompanyCertificateManagement-CCMAPI-Request:1.0.0
           - CompanyCertificateManagement-CCMAPI-Push:1.0.0
@@ -40,31 +42,37 @@ components:
           pattern: "^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
           type: string
           description: A UUIDv4 to uniquely identify a message
-          example: urn:uuid:24c2eaf5-c43a-4c31-8180-801cd7ac696e
+          examples:
+            - urn:uuid:24c2eaf5-c43a-4c31-8180-801cd7ac696e
         receiverBpn:
           pattern: "^BPNL[a-zA-Z0-9]{12}$"
           type: string
           description: The Business Partner Number of the receiving party
-          example: BPNL0000000002CD
+          examples:
+            - BPNL0000000002CD
         sentDateTime:
           type: string
           description: Time zone aware timestamp holding the date and the time the message was sent by the sending party. The value MUST be formatted according to the ISO 8601 standard
           format: date-time
-          example: 2024-10-07T10:15:00Z
+          examples:
+            - 2024-10-07T10:15:00Z
         expectedResponseBy:
           type: string
           description: Time zone aware timestamp holding the date and time by which the sending party expects a certain type of response from the receiving party
           format: date-time
-          example: 2024-10-07T10:15:00Z
+          examples:
+            - 2024-10-07T10:15:00Z
         relatedMessageId:
           pattern: "^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
           type: string
           description: Unique ID identifying a message somehow related to the current one
-          example: urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72
+          examples:
+            - urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72
         version:
           type: string
           description: The version number defining the structure and the semantics of the message's header
-          example: 3.1.0
+          examples:
+            - 3.1.0
 
     FeedbackUrlHeader:
       allOf:
@@ -74,7 +82,8 @@ components:
             senderFeedbackUrl:
               type: string
               description: URL of the EDC DSP endpoint to send feedback to
-              example: https://domain.tld/path/to/edc/api/v1/dsp
+              examples:
+                - https://domain.tld/path/to/edc/api/v1/dsp
 
     CertificateRequest:
       type: object

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -38,7 +38,7 @@ components:
           enum:
             - "CompanyCertificateManagement-CCMAPI-Push:1.0.0"
             - "CompanyCertificateManagement-CCMAPI-Request:1.0.0"
-            - "CompanyCertificateManagement-CCMAPI-Status:1.0.0"
+            - "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0"
             - "CompanyCertificateManagement-CCMAPI-Available:1.0.0"
         receiverBpn:
           type: string
@@ -371,7 +371,7 @@ components:
         header:
           senderBpn: "BPNL0000000001AB"
           messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
-          context: "CompanyCertificateManagement-CCMAPI-Pull:1.0.0"
+          context: "CompanyCertificateManagement-CCMAPI-Request:1.0.0"
           receiverBpn: "BPNL0000000002CD"
           sentDateTime: "2025-05-04T00:00:00-07:00Z"
           version: "3.1.0"
@@ -384,7 +384,7 @@ components:
         header:
           senderBpn: "BPNL0000000001AB"
           messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
-          context: "CompanyCertificateManagement-CCMAPI-Pull:1.0.0"
+          context: "CompanyCertificateManagement-CCMAPI-Request:1.0.0"
           receiverBpn: "BPNL0000000002CD"
           sentDateTime: "2025-05-04T00:00:00-07:00Z"
           version: "3.1.0"
@@ -529,7 +529,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CertificateStatus'
+              $ref: '#/components/schemas/CertificateFeedback'
             examples:
               Received:
                 $ref: '#/components/examples/CertificateReceivedFeedback'
@@ -539,7 +539,7 @@ paths:
                 $ref: '#/components/examples/CertificateRejectedFeedback'
       responses:
         '200':
-          description: Status updated successfully
+          description: Feedback updated successfully
 
   /companycertificate/available:
     post:
@@ -555,4 +555,3 @@ paths:
       responses:
         '200':
           description: Notification processed successfully
-

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -13,48 +13,58 @@ components:
   schemas:
     Header:
       type: object
+      description: Characteristic describing the common shared aspect Message Header of an incoming company certificate notification
       required:
-        - senderBpn
-        - context
-        - messageId
-        - receiverBpn
-        - sentDateTime
-        - version
+      - context
+      - messageId
+      - receiverBpn
+      - senderBpn
+      - sentDateTime
+      - version
       properties:
         senderBpn:
+          pattern: "^BPNL[a-zA-Z0-9]{12}$"
           type: string
-          description: The BPNL of the legal entity which send this request
-          examples:
-            - "BPNL0000000001AB"
-        messageId:
-          type: string
-          format: uuid
-          description: Identifier for this specific request being sent
-          examples:
-            - "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
+          description: The Business Partner Number of the sending party
+          example: BPNL0000000001AB
         context:
           type: string
-          description: The type of use case this request belongs to
+          description: The context defines the type of company certificate message
+          example: CompanyCertificateManagement-CCMAPI-Request:1.0.0
           enum:
-            - "CompanyCertificateManagement-CCMAPI-Push:1.0.0"
-            - "CompanyCertificateManagement-CCMAPI-Request:1.0.0"
-            - "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0"
-            - "CompanyCertificateManagement-CCMAPI-Available:1.0.0"
-        receiverBpn:
+          - CompanyCertificateManagement-CCMAPI-Request:1.0.0
+          - CompanyCertificateManagement-CCMAPI-Push:1.0.0
+          - CompanyCertificateManagement-CCMAPI-Feedback:1.0.0
+          - CompanyCertificateManagement-CCMAPI-Available:1.0.0
+        messageId:
+          pattern: "^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
           type: string
-          description: The intended receiver legal entity BPNL of this request
-          examples:
-            - "BPNL0000000002CD"
+          description: A UUIDv4 to uniquely identify a message
+          example: urn:uuid:24c2eaf5-c43a-4c31-8180-801cd7ac696e
+        receiverBpn:
+          pattern: "^BPNL[a-zA-Z0-9]{12}$"
+          type: string
+          description: The Business Partner Number of the receiving party
+          example: BPNL0000000002CD
         sentDateTime:
           type: string
-          description: The full time and date with timezone on when this request has been sent by the sender
+          description: Time zone aware timestamp holding the date and the time the message was sent by the sending party. The value MUST be formatted according to the ISO 8601 standard
           format: date-time
-          examples:
-            - "2025-05-04T00:00:00-07:00Z"
+          example: 2024-10-07T10:15:00Z
+        expectedResponseBy:
+          type: string
+          description: Time zone aware timestamp holding the date and time by which the sending party expects a certain type of response from the receiving party
+          format: date-time
+          example: 2024-10-07T10:15:00Z
+        relatedMessageId:
+          pattern: "^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+          type: string
+          description: Unique ID identifying a message somehow related to the current one
+          example: urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72
         version:
           type: string
-          examples:
-            - "3.1.0"
+          description: The version number defining the structure and the semantics of the message's header
+          example: 3.1.0
 
     FeedbackUrlHeader:
       allOf:
@@ -63,10 +73,8 @@ components:
           properties:
             senderFeedbackUrl:
               type: string
-              description: The DSP URL from where the sender of the request expectes to receive feedback
-              examples:
-                - "https://domain.tld/path/to/edc/api/v1/dsp"
-
+              description: URL of the EDC DSP endpoint to send feedback to
+              example: https://domain.tld/path/to/edc/api/v1/dsp
 
     CertificateRequest:
       type: object

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -26,7 +26,7 @@ components:
               enum:
               - CompanyCertificateManagement-CCMAPI-Request:1.0.0
               - CompanyCertificateManagement-CCMAPI-Push:1.0.0
-              - CompanyCertificateManagement-CCMAPI-Feedback:1.0.0
+              - CompanyCertificateManagement-CCMAPI-Status:1.0.0
               - CompanyCertificateManagement-CCMAPI-Available:1.0.0
 
     FeedbackUrlHeader:
@@ -36,7 +36,7 @@ components:
           properties:
             senderFeedbackUrl:
               type: string
-              description: URL of the EDC DSP endpoint to send feedback to
+              description: URL of the EDC DSP endpoint to send feedback on the status to
               examples:
                 - https://domain.tld/path/to/edc/api/v1/dsp
 
@@ -189,7 +189,7 @@ components:
           examples:
             - Site BPNS000000000003 is unknown
 
-    CertificateFeedback:
+    CertificateStatus:
       type: object
       required:
         - header
@@ -283,13 +283,13 @@ components:
               locationErrors:
                 - message: "Site BPNS000000000003 is unknown"
 
-    CertificateAcceptedFeedback:
+    CertificateAcceptedStatus:
       summary: Consumer accepts received certificate
       value:
         header:
           senderBpn: "BPNL0000000001AB"
           messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
-          context: "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0"
+          context: "CompanyCertificateManagement-CCMAPI-Status:1.0.0"
           receiverBpn: "BPNL0000000002CD"
           sentDateTime: "2025-05-04T00:00:00-07:00Z"
           version: "3.1.0"
@@ -299,13 +299,13 @@ components:
           locationBpns:
             - "BPNS000000000003"
 
-    CertificateReceivedFeedback:
+    CertificateReceivedStatus:
       summary: Consumer received certificate
       value:
         header:
           senderBpn: "BPNL0000000001AB"
           messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
-          context: "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0"
+          context: "CompanyCertificateManagement-CCMAPI-Status:1.0.0"
           receiverBpn: "BPNL0000000002CD"
           sentDateTime: "2025-05-04T00:00:00-07:00Z"
           version: "3.1.0"
@@ -315,13 +315,13 @@ components:
           locationBpns:
             - "BPNS000000000003"
 
-    CertificateRejectedFeedback:
+    CertificateRejectedStatus:
       summary: Consumer rejected received certificate
       value:
         header:
           senderBpn: "BPNL0000000001AB"
           messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
-          context: "CompanyCertificateManagement-CCMAPI-Feedback:1.0.0"
+          context: "CompanyCertificateManagement-CCMAPI-Status:1.0.0"
           receiverBpn: "BPNL0000000002CD"
           sentDateTime: "2025-05-04T00:00:00-07:00Z"
           version: "3.1.0"
@@ -391,7 +391,7 @@ paths:
 
   /companycertificate/push:
     post:
-      summary: Notify that a certificate is available along with its content
+      summary: Certificate provider sends a certificate to the certificate consumer
       tags:
         - Certificate Consumer
       requestBody:
@@ -404,9 +404,9 @@ paths:
         '200':
           description: Notification processed successfully
 
-  /companycertificate/feedback:
+  /companycertificate/status:
     post:
-      summary: Send feedback to an obtained certificate
+      summary: Certificate consumer sends feedback on the status of a consumed certificate to the certificate provider
       tags:
         - Certificate Provider
       requestBody:
@@ -414,17 +414,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CertificateFeedback'
+              $ref: '#/components/schemas/CertificateStatus'
             examples:
               Received:
-                $ref: '#/components/examples/CertificateReceivedFeedback'
+                $ref: '#/components/examples/CertificateReceivedStatus'
               Accepted:
-                $ref: '#/components/examples/CertificateAcceptedFeedback'
+                $ref: '#/components/examples/CertificateAcceptedStatus'
               Rejected:
-                $ref: '#/components/examples/CertificateRejectedFeedback'
+                $ref: '#/components/examples/CertificateRejectedStatus'
       responses:
         '200':
-          description: Feedback updated successfully
+          description: Status updated successfully
 
   /companycertificate/available:
     post:

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -92,7 +92,7 @@ components:
               type: string
               description: The type of certificate the certificate consumer requests
               examples:
-                - "ISO9001"
+                - "iso9001"
             locationBpns:
               type: array
               description: The BPNs of the site or address locations for which the certificate consumer requests the certificate

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -173,7 +173,7 @@ components:
     BpnLocation:
       type: string
       description: The BPNA or BPNS of either an address or site location
-      pattern: "^BPN[A|S][A-Z0-9]{11}$"
+      pattern: "^BPN[AS][A-Z0-9]{12}$"
       examples:
         - "BPNA000000000001"
         - "BPNS000000000002"
@@ -295,7 +295,7 @@ components:
           requestStatus: "COMPLETED"
           documentId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba"
     CertificateRequestRejected:
-      summary: A response for a rejected certificated request process
+      summary: A response for a rejected certificate request process
       value:
         header:
           senderBpn: "BPNL0000000001AB"

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -39,6 +39,7 @@ components:
             - "CompanyCertificateManagement-CCMAPI-Push:1.0.0"
             - "CompanyCertificateManagement-CCMAPI-Request:1.0.0"
             - "CompanyCertificateManagement-CCMAPI-Status:1.0.0"
+            - "CompanyCertificateManagement-CCMAPI-Available:1.0.0"
         receiverBpn:
           type: string
           description: The intended receiver legal entity BPNL of this request
@@ -292,40 +293,6 @@ components:
           examples:
             - Site BPNS000000000003 is unknown
 
-    CertificateStatus:
-      type: object
-      required:
-        - header
-        - content
-      properties:
-        header:
-          $ref: '#/components/schemas/Header'
-        content:
-          type: object
-          required:
-            - documentId
-            - certificateStatus
-            - locationBpns
-          properties:
-            documentId:
-              type: string
-              format: uuid
-            certificateStatus:
-              type: string
-              enum: [ACCEPTED, REJECTED, RECEIVED]
-            certificateErrors:
-              type: array
-              items:
-                $ref: '#/components/schemas/Error'
-            locationBpns:
-              type: array
-              items:
-                $ref: '#/components/schemas/BpnLocation'
-            locationErrors:
-              type: array
-              items:
-                $ref: '#/components/schemas/LocationErrorCollection'
-
     CertificateFeedback:
       type: object
       required:
@@ -359,6 +326,31 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/LocationErrorCollection'
+
+    CertificateAvailable:
+      type: object
+      required:
+        - header
+        - content
+      properties:
+        header:
+          $ref: '#/components/schemas/Header'
+        content:
+          type: object
+          required:
+            - documentId
+            - certificateType
+          properties:
+            documentId:
+              type: string
+              format: uuid
+            certificateType:
+              type: string
+              description: "Type of the certificate as defined on the document, valid types are registered at BPN metadatacontroller"
+            locationBpns:
+              type: array
+              items:
+                $ref: '#/components/schemas/BpnLocation'
 
     TrustValidator:
       description: The Business Partner Number (BPN) of the data service provider who validated the given certificate
@@ -458,6 +450,21 @@ components:
               locationErrors:
                 - message: "Site BPNS000000000003 is unknown"
 
+    CertificateAvailable:
+      summary: Provider notifies consumer that a certificate is available
+      value:
+        header:
+          senderBpn: "BPNL0000000001AB"
+          messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
+          context: "CompanyCertificateManagement-CCMAPI-Available:1.0.0"
+          receiverBpn: "BPNL0000000002CD"
+          sentDateTime: "2025-05-04T00:00:00-07:00Z"
+          version: "3.1.0"
+        content:
+          documentId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          certificateType: "iso9001"
+          locationBpns:
+            - "BPNS000000000003"
 
 
 
@@ -533,3 +540,19 @@ paths:
       responses:
         '200':
           description: Status updated successfully
+
+  /companycertificate/available:
+    post:
+      summary: Certificate provider notifies the certificate consumer that a certificate is available
+      tags:
+        - Certificate Consumer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CertificateAvailable'
+      responses:
+        '200':
+          description: Notification processed successfully
+

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -107,8 +107,6 @@ components:
               items:
                 $ref: '#/components/schemas/BpnLocation'
 
-
-
     CertificateRequestFinishedResponse:
       type: object
       required:
@@ -185,8 +183,6 @@ components:
       examples:
         - "BPNA000000000001"
         - "BPNS000000000002"
-
-
 
     CertificatePush:
       type: object
@@ -302,6 +298,7 @@ components:
         content:
           requestStatus: "COMPLETED"
           documentId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba"
+
     CertificateRequestRejected:
       summary: A response for a rejected certificate request process
       value:
@@ -321,6 +318,7 @@ components:
             - bpn: "BPNS000000000003"
               locationErrors:
                 - message: "Site BPNS000000000003 is unknown"
+
     CertificateAcceptedFeedback:
       summary: Consumer accepts received certificate
       value:
@@ -336,6 +334,7 @@ components:
           certificateStatus: "ACCEPTED"
           locationBpns:
             - "BPNS000000000003"
+
     CertificateReceivedFeedback:
       summary: Consumer received certificate
       value:
@@ -351,6 +350,7 @@ components:
           certificateStatus: "RECEIVED"
           locationBpns:
             - "BPNS000000000003"
+
     CertificateRejectedFeedback:
       summary: Consumer rejected received certificate
       value:
@@ -390,8 +390,6 @@ components:
           locationBpns:
             - "BPNS000000000003"
 
-
-
 paths:
   /companycertificate/request:
     post:
@@ -422,7 +420,6 @@ paths:
                   $ref: '#/components/examples/CertificateRequestCompleted'
                 Rejected:
                   $ref: '#/components/examples/CertificateRequestRejected'
-
         '400':
           description: Request malformed and can not be processed
         '500':

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -12,67 +12,22 @@ tags:
 components:
   schemas:
     Header:
-      type: object
-      description: Characteristic describing the common shared aspect Message Header of an incoming company certificate notification
-      required:
-      - context
-      - messageId
-      - receiverBpn
-      - senderBpn
-      - sentDateTime
-      - version
-      properties:
-        senderBpn:
-          pattern: "^BPNL[a-zA-Z0-9]{12}$"
-          type: string
-          description: The Business Partner Number of the sending party
-          examples:
-            - BPNL0000000001AB
-        context:
-          type: string
-          description: The context defines the type of company certificate message
-          examples:
-            - CompanyCertificateManagement-CCMAPI-Request:1.0.0
-          enum:
-          - CompanyCertificateManagement-CCMAPI-Request:1.0.0
-          - CompanyCertificateManagement-CCMAPI-Push:1.0.0
-          - CompanyCertificateManagement-CCMAPI-Feedback:1.0.0
-          - CompanyCertificateManagement-CCMAPI-Available:1.0.0
-        messageId:
-          pattern: "^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-          type: string
-          description: A UUIDv4 to uniquely identify a message
-          examples:
-            - urn:uuid:24c2eaf5-c43a-4c31-8180-801cd7ac696e
-        receiverBpn:
-          pattern: "^BPNL[a-zA-Z0-9]{12}$"
-          type: string
-          description: The Business Partner Number of the receiving party
-          examples:
-            - BPNL0000000002CD
-        sentDateTime:
-          type: string
-          description: Time zone aware timestamp holding the date and the time the message was sent by the sending party. The value MUST be formatted according to the ISO 8601 standard
-          format: date-time
-          examples:
-            - 2024-10-07T10:15:00Z
-        expectedResponseBy:
-          type: string
-          description: Time zone aware timestamp holding the date and time by which the sending party expects a certain type of response from the receiving party
-          format: date-time
-          examples:
-            - 2024-10-07T10:15:00Z
-        relatedMessageId:
-          pattern: "^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-          type: string
-          description: Unique ID identifying a message somehow related to the current one
-          examples:
-            - urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72
-        version:
-          type: string
-          description: The version number defining the structure and the semantics of the message's header
-          examples:
-            - 3.1.0
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/eclipse-tractusx/sldt-semantic-models/refs/heads/main/io.catenax.shared.message_header/3.0.0/gen/MessageHeaderAspect-schema.json#/properties/header'
+        - type: object
+          required:
+            - context
+          properties:
+            context:
+              type: string
+              description: The context defines the type of company certificate message
+              examples:
+                - CompanyCertificateManagement-CCMAPI-Request:1.0.0
+              enum:
+              - CompanyCertificateManagement-CCMAPI-Request:1.0.0
+              - CompanyCertificateManagement-CCMAPI-Push:1.0.0
+              - CompanyCertificateManagement-CCMAPI-Feedback:1.0.0
+              - CompanyCertificateManagement-CCMAPI-Available:1.0.0
 
     FeedbackUrlHeader:
       allOf:

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/openapi-spec.yaml
@@ -12,22 +12,68 @@ tags:
 components:
   schemas:
     Header:
-      allOf:
-        - $ref: 'https://raw.githubusercontent.com/eclipse-tractusx/sldt-semantic-models/refs/heads/main/io.catenax.shared.message_header/3.0.0/gen/MessageHeaderAspect-schema.json#/properties/header'
-        - type: object
-          required:
-            - context
-          properties:
-            context:
-              type: string
-              description: The context defines the type of company certificate message
-              examples:
-                - CompanyCertificateManagement-CCMAPI-Request:1.0.0
-              enum:
-              - CompanyCertificateManagement-CCMAPI-Request:1.0.0
-              - CompanyCertificateManagement-CCMAPI-Push:1.0.0
-              - CompanyCertificateManagement-CCMAPI-Status:1.0.0
-              - CompanyCertificateManagement-CCMAPI-Available:1.0.0
+      description: Characteristic describing the common shared aspect Message Header
+      required:
+      - context
+      - messageId
+      - receiverBpn
+      - senderBpn
+      - sentDateTime
+      - version
+      type: object
+      properties:
+        messageId:
+          pattern: "^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+          type: string
+          description: A UUIDv4 to uniquely identify a message
+          examples:
+            - urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72
+            - e4da568b-8cf1-4f5f-a96a-cf26265b2c72
+        context:
+          type: string
+          description: The context defines the type of company certificate message
+          examples:
+            - CompanyCertificateManagement-CCMAPI-Request:1.0.0
+          enum:
+          - CompanyCertificateManagement-CCMAPI-Request:1.0.0
+          - CompanyCertificateManagement-CCMAPI-Push:1.0.0
+          - CompanyCertificateManagement-CCMAPI-Status:1.0.0
+          - CompanyCertificateManagement-CCMAPI-Available:1.0.0
+        sentDateTime:
+          type: string
+          description: Time zone aware timestamp holding the date and the time the
+            message was sent by the sending party. The value MUST be formatted according
+            to the ISO 8601 standard
+          format: date-time
+          examples:
+            - 2024-10-07T10:15:00Z
+        senderBpn:
+          pattern: "^BPNL[a-zA-Z0-9]{12}$"
+          type: string
+          description: The Business Partner Number of the sending party
+          examples:
+            - BPNL0000000001AB
+        receiverBpn:
+          pattern: "^BPNL[a-zA-Z0-9]{12}$"
+          type: string
+          description: The Business Partner Number of the receiving party
+          examples:
+            - BPNL0000000002CD
+        relatedMessageId:
+          pattern: "^(?:urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+          type: string
+          description: Unique ID identifying a message somehow related to the current
+            one
+          examples:
+            - urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72
+            - e4da568b-8cf1-4f5f-a96a-cf26265b2c72
+        version:
+          pattern: "^(0|[1-9][0-9]*).(0|[1-9][0-9]*).(0|[1-9][0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(.[0-9A-Za-z-]+)*)?([0-9A-Za-z-]+(.[0-9A-Za-z-]+)*)?$"
+          type: string
+          description: The unique identifier of the aspect model defining the structure
+            and the semantics of the message's header
+          examples:
+            - 3.1.0
 
     FeedbackUrlHeader:
       allOf:
@@ -36,7 +82,7 @@ components:
           properties:
             senderFeedbackUrl:
               type: string
-              description: URL of the EDC DSP endpoint to send feedback on the status to
+              description: URL of the EDC DSP endpoint to send feedback to
               examples:
                 - https://domain.tld/path/to/edc/api/v1/dsp
 
@@ -196,7 +242,7 @@ components:
         - content
       properties:
         header:
-          $ref: '#/components/schemas/Header'
+          $ref: '#/components/schemas/FeedbackUrlHeader'
         content:
           type: object
           required:
@@ -230,7 +276,7 @@ components:
         - content
       properties:
         header:
-          $ref: '#/components/schemas/Header'
+          $ref: '#/components/schemas/FeedbackUrlHeader'
         content:
           type: object
           required:
@@ -253,11 +299,12 @@ components:
       summary: A response for a successfully completed certificate request process
       value:
         header:
-          senderBpn: "BPNL0000000001AB"
-          messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
+          messagedId: "urn:uuid:3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
           context: "CompanyCertificateManagement-CCMAPI-Request:1.0.0"
+          sentDateTime: "2024-10-07T10:15:00Z"
+          senderBpn: "BPNL0000000001AB"
           receiverBpn: "BPNL0000000002CD"
-          sentDateTime: "2025-05-04T00:00:00-07:00Z"
+          relatedMessageId: "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72"
           version: "3.1.0"
         content:
           requestStatus: "COMPLETED"
@@ -267,11 +314,12 @@ components:
       summary: A response for a rejected certificate request process
       value:
         header:
-          senderBpn: "BPNL0000000001AB"
-          messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
+          messagedId: "urn:uuid:3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
           context: "CompanyCertificateManagement-CCMAPI-Request:1.0.0"
+          sentDateTime: "2024-10-07T10:15:00Z"
+          senderBpn: "BPNL0000000001AB"
           receiverBpn: "BPNL0000000002CD"
-          sentDateTime: "2025-05-04T00:00:00-07:00Z"
+          relatedMessageId: "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72"
           version: "3.1.0"
         content:
           requestStatus: "REJECTED"
@@ -283,35 +331,39 @@ components:
               locationErrors:
                 - message: "Site BPNS000000000003 is unknown"
 
-    CertificateAcceptedStatus:
-      summary: Consumer accepts received certificate
-      value:
-        header:
-          senderBpn: "BPNL0000000001AB"
-          messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
-          context: "CompanyCertificateManagement-CCMAPI-Status:1.0.0"
-          receiverBpn: "BPNL0000000002CD"
-          sentDateTime: "2025-05-04T00:00:00-07:00Z"
-          version: "3.1.0"
-        content:
-          documentId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
-          certificateStatus: "ACCEPTED"
-          locationBpns:
-            - "BPNS000000000003"
-
     CertificateReceivedStatus:
       summary: Consumer received certificate
       value:
         header:
-          senderBpn: "BPNL0000000001AB"
-          messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
+          messagedId: "urn:uuid:3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
           context: "CompanyCertificateManagement-CCMAPI-Status:1.0.0"
+          sentDateTime: "2024-10-07T10:15:00Z"
+          senderBpn: "BPNL0000000001AB"
           receiverBpn: "BPNL0000000002CD"
-          sentDateTime: "2025-05-04T00:00:00-07:00Z"
+          relatedMessageId: "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72"
           version: "3.1.0"
+          senderFeedbackUrl: "https://domain.tld/path/to/edc/api/v1/dsp"
         content:
           documentId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
           certificateStatus: "RECEIVED"
+          locationBpns:
+            - "BPNS000000000003"
+
+    CertificateAcceptedStatus:
+      summary: Consumer accepts received certificate
+      value:
+        header:
+          messagedId: "urn:uuid:3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
+          context: "CompanyCertificateManagement-CCMAPI-Status:1.0.0"
+          sentDateTime: "2024-10-07T10:15:00Z"
+          senderBpn: "BPNL0000000001AB"
+          receiverBpn: "BPNL0000000002CD"
+          relatedMessageId: "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72"
+          version: "3.1.0"
+          senderFeedbackUrl: "https://domain.tld/path/to/edc/api/v1/dsp"
+        content:
+          documentId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          certificateStatus: "ACCEPTED"
           locationBpns:
             - "BPNS000000000003"
 
@@ -319,12 +371,14 @@ components:
       summary: Consumer rejected received certificate
       value:
         header:
-          senderBpn: "BPNL0000000001AB"
-          messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
+          messagedId: "urn:uuid:3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
           context: "CompanyCertificateManagement-CCMAPI-Status:1.0.0"
+          sentDateTime: "2024-10-07T10:15:00Z"
+          senderBpn: "BPNL0000000001AB"
           receiverBpn: "BPNL0000000002CD"
-          sentDateTime: "2025-05-04T00:00:00-07:00Z"
+          relatedMessageId: "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72"
           version: "3.1.0"
+          senderFeedbackUrl: "https://domain.tld/path/to/edc/api/v1/dsp"
         content:
           documentId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
           certificateStatus: "REJECTED"
@@ -342,12 +396,14 @@ components:
       summary: Provider notifies consumer that a certificate is available
       value:
         header:
-          senderBpn: "BPNL0000000001AB"
-          messagedId: "3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
+          messagedId: "urn:uuid:3b4edc05-e214-47a1-b0c2-1d831cdd9ba9"
           context: "CompanyCertificateManagement-CCMAPI-Available:1.0.0"
+          sentDateTime: "2024-10-07T10:15:00Z"
+          senderBpn: "BPNL0000000001AB"
           receiverBpn: "BPNL0000000002CD"
-          sentDateTime: "2025-05-04T00:00:00-07:00Z"
+          relatedMessageId: "urn:uuid:e4da568b-8cf1-4f5f-a96a-cf26265b2c72"
           version: "3.1.0"
+          senderFeedbackUrl: "https://domain.tld/path/to/edc/api/v1/dsp"
         content:
           documentId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
           certificateType: "iso9001"
@@ -387,7 +443,7 @@ paths:
         '400':
           description: Request malformed and can not be processed
         '500':
-          description: Internal server error has occured
+          description: Internal server error
 
   /companycertificate/push:
     post:
@@ -403,6 +459,8 @@ paths:
       responses:
         '200':
           description: Notification processed successfully
+        '500':
+          description: Internal server error
 
   /companycertificate/status:
     post:
@@ -425,6 +483,8 @@ paths:
       responses:
         '200':
           description: Status updated successfully
+        '500':
+          description: Internal server error
 
   /companycertificate/available:
     post:
@@ -437,6 +497,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CertificateAvailable'
+            examples:
+              CertificateAvailable:
+                $ref: '#/components/examples/CertificateAvailable'
       responses:
         '200':
           description: Notification processed successfully


### PR DESCRIPTION
Introduced changes:
- Added missing certificate type examples
- Added link to `Industry Core: Basics` reference in `4.1 NORMATIVE REFERENCES`
- Reintroduced Certificate Available notification
- Fixed formatting of JSON examples
- Fixed spelling of certificate type in examples
- Fixed context references in openAPI yaml example
- Removed unused schemas from openAPI yaml example
- Fixed BpnLocation pattern in openAPI yaml example
- Removed `relatedMessageId` attribute from the example payloads because it is optional
- Adjusted `Header` in the openAPI yaml example to reuse the [message header aspect model](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.shared.message_header/3.0.0)
- Fixed formatting of openAPI yaml example
- Reverted from  `Feedback` notifications back to `Status` notifications to avoid introducing breaking changes
- Reverted dct subject renaming for the CCMAPI asset to avoid introducing breaking changes
- Formatting and QoL changes
- Removed the sentence `This request can be sent by the Certificate Consumer continuously, for updates on the request state on Certificate Provider side.` as discussed in the meeting on 12.11.