### PR TITLE
feat: add CloudEvents CCM proposal merged with PR #318 (combined + me…

### DIFF
--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0000-CloudEventsFoundation-combined.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0000-CloudEventsFoundation-combined.md
@@ -1,0 +1,362 @@
+# CX-0000 Notification Foundation (CX-151?)
+
+## Abstract
+
+This standard defines a protocol-agnostic foundation for event-based data exchange built on the CloudEvents
+specification. It provides the base event structure and mechanisms that can be used across multiple Catena-X use cases
+and domains.
+
+## 1 Introduction
+
+This standard establishes the foundational layer for event-based communication, based on the CloudEvents v1+
+specification. Note that implementations should periodically upgrade support for minor (backward-compatible) versions of
+that specification. It defines core event structures, attribute requirements, and extension mechanisms without binding
+to specific transport protocols.
+
+### 1.1 Audience & Scope
+
+This specification covers:
+
+- Base event structure and attributes
+- Type system and data encoding
+- Extension mechanisms
+- Protocol-agnostic design principles
+
+### 1.2 Conformance and Proof of Conformity
+
+> *This section is normative*
+
+The keywords **MAY**, **MUST**, **MUST NOT**, **OPTIONAL**, **RECOMMENDED**, **REQUIRED**, **SHOULD**, and **SHOULD NOT**
+in this document are to be interpreted as described in BCP 14 [RFC2119](#rfc2119) [RFC8174](#rfc8174) when, and only
+when, they appear in all capitals, as shown here.
+
+To prove conformity:
+
+- Events **MUST** conform to the CloudEvents v1+ specification
+- Events **MUST** be serializable in JSON format
+- Events **MUST** include all REQUIRED attributes as defined in section 2.1
+- JSON schemas for event formats **MUST** be provided for validation
+
+### 1.3 Terminology
+
+> *This section is non-normative*
+
+**Event**: A data record expressing an occurrence and its context
+
+**Producer**: The system or process that creates events
+
+**Consumer**: The system or process that receives and processes events
+
+**Source**: An identifier for the context in which an event occurred
+
+**Type**: A string describing the nature of the event
+
+**CloudEvents**: The CNCF specification for describing events in a common format
+
+## 2 Event Specification
+
+> *This section is normative*
+
+### 2.1 Base Event Structure
+
+All events conforming to this standard **MUST** be valid CloudEvents v1.0.2 events [CloudEvents](#cloudevents).
+
+#### 2.1.1 Required Attributes
+
+The following CloudEvents attributes are **REQUIRED**:
+
+| Attribute     | Type          | Description                                                                                                   |
+|---------------|---------------|---------------------------------------------------------------------------------------------------------------|
+| `id`          | String        | Unique identifier for the event. Producers MUST ensure that `source` + `id` is unique for each distinct event |
+| `source`      | URI-reference | The source DID                                                                                                |
+| `specversion` | String        | CloudEvents specification version. MUST be "1.0"                                                              |
+| `type`        | String        | Event type identifier. MUST be a non-empty string. SHOULD use reverse-DNS notation                            |
+
+#### 2.1.2 Required Extension Attributes
+
+| Attribute   | Type   | Description    |
+|-------------|--------|----------------|
+| `sourcebpn` | String | The source BPN |
+
+#### 2.1.3 Recommended Attributes
+
+The following CloudEvents attributes are **RECOMMENDED**:
+
+| Attribute         | Type      | Description                                               |
+|-------------------|-----------|-----------------------------------------------------------|
+| `time`            | Timestamp | [RFC3339](#rfc3339) timestamp of when the event occurred  |
+| `datacontenttype` | String    | Media type of the data payload (e.g., "application/json") |
+| `dataschema`      | URI       | URI identifying the schema of the data payload            |
+
+If `datacontenttype` is not specified, the event **MUST** be interpreted as `application/json`.
+
+#### 2.1.4 Optional Attributes
+
+| Attribute          | Type   | Description                                             |
+|--------------------|--------|---------------------------------------------------------|
+| `subject`          | String | Subject of the event in the context of the event source |
+| `relatedmessageid` | String | A related message id                                    |
+
+### 2.2 Identifier Requirements
+
+Event IDs **MUST** be unique within the scope of a `source`:
+
+- Combination of `source` + `id` **MUST** uniquely identify an event
+- Duplicate events (e.g., retries) **MUST** reuse the same `source` and `id`
+- Event IDs **MUST** be UUIDs as defined by [RFC9562](#rfc9562)
+
+> NOTE: Consumers **MUST NOT** assume which UUID version a given `id` uses. The `id` is to be treated as an opaque
+> identifier and used only for equality comparison; its internal structure (version, timestamp, or any other embedded
+> data) **MUST NOT** be interpreted.
+
+### 2.3 Event Types
+
+#### 2.3.1 Type Naming Convention
+
+> ISSUE: We should consider using the `org.tractus-x` domain instead of `org.catena-x` for event types. This may
+> make the event types and specification more generic for reuse across other dataspaces.
+
+Event types **MUST** follow reverse-DNS notation where the domain is `org.catena-x`:
+
+`<domain>.<use case>.<specifier>.<version>`
+
+The `domain` and `use case` **MUST** be in lowercase.
+
+The `specifier` **MUST** be in Camel Case, for example:
+
+```
+org.catena-x.pcf.NotificationEvent.v1
+```
+
+#### 2.3.2 Type Versioning
+
+Version information **MUST** be encoded as follows:
+
+`v<major>`
+
+for example `v1`. Minor/patch versions **MUST NOT** be in the type name
+
+### 2.4 Event Data
+
+#### 2.4.1 Data Payload
+
+The `data` attribute **MAY** contain domain-specific information of a valid JSON type (object, array, string, number,
+boolean, null). The `data` attribute **SHOULD** have a schema defined via the `dataschema` attribute.
+
+#### 2.4.2 Data Content Type
+
+When `data` is present, `datacontenttype` **SHOULD** be specified. If specified, it **MUST** be a valid media type as
+defined by [RFC2046](#rfc2046). If `data` is present and `datacontenttype` is not specified, implementation **MUST** default to
+interpreting the data payload as "application/json". If `data_base64` is present and `datacontenttype` is not specified,
+implementation **MUST** default to interpreting the data payload as "application/octet-stream".
+
+### 2.5 Extension Attributes
+
+#### 2.5.1 Defining Extensions
+
+Custom attributes **MAY** be added following CloudEvents naming rules:
+
+- The attribute **MUST** consist of lowercase letters (a-z) or digits (0–9)
+- The attribute **MUST** be at least one character, **SHOULD NOT** exceed 20 characters
+- The attribute **SHOULD** start with a letter
+- The attribute **MUST NOT** use the name `data`, `data_base64`, or any CloudEvents reserved attribute names
+
+#### 2.5.2 Extension Attribute Types
+
+Extension attributes **MUST** use CloudEvents type system:
+
+- Boolean
+- Integer
+- String
+- Binary
+- URI
+- URI-reference
+- Timestamp
+
+## 3 Data Formats
+
+> *This section is normative*
+
+### 3.1 JSON Format
+
+All implementations **MUST** support JSON serialization per the CloudEvents JSON format specification
+[CloudEvents-JSON](#cloudevents-json).
+
+#### 3.2 JSON Schema
+
+JSON Schema for base CloudEvents structure using non-binary data:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "specversion",
+    "type",
+    "source",
+    "id"
+  ],
+  "properties": {
+    "specversion": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "type": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "string",
+      "format": "uri-reference",
+      "minLength": 1
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "datacontenttype": {
+      "type": "string"
+    },
+    "dataschema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "subject": {
+      "type": "string",
+      "minLength": 1
+    },
+    "data": {}
+  },
+  "additionalProperties": true
+}
+```
+
+## 4 HTTPS Binding
+
+CloudEvents **MUST** follow the HTTP Protocol Binding for CloudEvents [CloudEvents-HTTP](#cloudevents-http).
+
+When using HTTPS and non-binary content, events **MUST** be serialized in JSON format using the JSON structured mode.
+
+Batch events **MAY** be used.
+
+### 4.1 Security and Authorization
+
+All endpoints **MUST** use HTTPS, HTTP over TLS 1.2 or higher. Authorization **MUST** adhere to the Data Plane Signaling
+Token Refresh Protocol [DPS-TokenRefresh](#dps-token-refresh).
+
+If a client is not authorized for an endpoint request, the API **MUST** return `401 Unauthorized` or `404 Not Found`.
+
+## 5 Examples
+
+> *This section is non-normative*
+
+### 5.1 Single Event
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.pcf.NotificationEvent.v1",
+  "id": "e678a546-8bb7-4491-8765-046fa39ac76c",
+  "source": "did:web:example.com",
+  "sourcebpn": "BPNL0000000000AA",
+  "time": "2025-02-27T12:34:56.789Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://example.com/schemas/status.json",
+  "subject": "part/12345",
+  "data": {
+    "partId": "12345",
+    "status": "ready"
+  }
+}
+```
+
+### 5.2 Batch Event
+
+```json
+[
+  {
+    "specversion": "1.0",
+    "type": "org.catena-x.pcf.NotificationEvent.v1",
+    "id": "e678a546-8bb7-4491-8765-046fa39ac76c",
+    "source": "did:web:example.com",
+    "sourcebpn": "BPNL0000000000AA",
+    "time": "2025-02-27T12:34:56.789Z",
+    "datacontenttype": "application/json",
+    "dataschema": "https://example.com/schemas/status.json",
+    "subject": "part/12345",
+    "data": {
+      "partId": "12345",
+      "status": "ready"
+    }
+  },
+  {
+    "specversion": "1.0",
+    "type": "org.catena-x.pcf.NotificationEvent.v1",
+    "id": "2b51c8ed-2f06-4220-a454-52bd3d1b4797",
+    "source": "did:web:example.com",
+    "sourcebpn": "BPNL0000000000AA",
+    "time": "2025-02-27T12:34:56.789Z",
+    "datacontenttype": "application/json",
+    "dataschema": "https://example.com/schemas/status.json",
+    "subject": "part/67890",
+    "data": {
+      "partId": "67890",
+      "status": "updated"
+    }
+  }
+]
+```
+
+## 6 References
+
+### 6.1 Normative References
+
+<a id="cloudevents"></a>
+**[CloudEvents]** Cloud Native Computing Foundation, "CloudEvents 1.0.2 — Core Specification",
+<https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md>.
+
+<a id="cloudevents-http"></a>
+**[CloudEvents-HTTP]** Cloud Native Computing Foundation, "HTTP Protocol Binding for CloudEvents 1.0.2",
+<https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/bindings/http-protocol-binding.md>.
+
+<a id="cloudevents-json"></a>
+**[CloudEvents-JSON]** Cloud Native Computing Foundation, "JSON Event Format for CloudEvents 1.0.2",
+<https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/json-format.md>.
+
+<a id="dps-token-refresh"></a>
+**[DPS-TokenRefresh]** Eclipse Data Plane Signaling Working Group, "Data Plane Signaling Token Refresh Protocol",
+<https://github.com/eclipse-dataplane-signaling/dataplane-signaling>.
+
+<a id="rfc2046"></a>
+**[RFC2046]** Freed, N. and Borenstein, N., "Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types",
+RFC 2046, November 1996, <https://www.rfc-editor.org/rfc/rfc2046>.
+
+<a id="rfc2119"></a>
+**[RFC2119]** Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997,
+<https://www.rfc-editor.org/rfc/rfc2119>.
+
+<a id="rfc3339"></a>
+**[RFC3339]** Klyne, G. and Newman, C., "Date and Time on the Internet: Timestamps", RFC 3339, July 2002,
+<https://www.rfc-editor.org/rfc/rfc3339>.
+
+<a id="rfc3986"></a>
+**[RFC3986]** Berners-Lee, T., Fielding, R., and Masinter, L., "Uniform Resource Identifier (URI): Generic Syntax",
+STD 66, RFC 3986, January 2005, <https://www.rfc-editor.org/rfc/rfc3986>.
+
+<a id="rfc8174"></a>
+**[RFC8174]** Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, May 2017,
+<https://www.rfc-editor.org/rfc/rfc8174>.
+
+<a id="rfc9562"></a>
+**[RFC9562]** Davis, K., Peabody, B., and Leach, P., "Universally Unique IDentifiers (UUIDs)", RFC 9562, May 2024,
+<https://www.rfc-editor.org/rfc/rfc9562>.
+
+### 6.2 Non-Normative References
+
+<a id="cloudevents-primer"></a>
+**[CloudEvents-Primer]** Cloud Native Computing Foundation, "CloudEvents Primer",
+<https://github.com/cloudevents/spec/blob/main/cloudevents/primer.md>.

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0000-CloudEventsFoundation-jim.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0000-CloudEventsFoundation-jim.md
@@ -1,0 +1,362 @@
+# CX-0000 Notification Foundation (CX-151?)
+
+## Abstract
+
+This standard defines a protocol-agnostic foundation for event-based data exchange built on the CloudEvents
+specification. It provides the base event structure and mechanisms that can be used across multiple Catena-X use cases
+and domains.
+
+## 1 Introduction
+
+This standard establishes the foundational layer for event-based communication, based on the CloudEvents v1+
+specification. Note that implementations should periodically upgrade support for minor (backward-compatible) versions of
+that specification. It defines core event structures, attribute requirements, and extension mechanisms without binding
+to specific transport protocols.
+
+### 1.1 Audience & Scope
+
+This specification covers:
+
+- Base event structure and attributes
+- Type system and data encoding
+- Extension mechanisms
+- Protocol-agnostic design principles
+
+### 1.2 Conformance and Proof of Conformity
+
+> *This section is normative*
+
+The keywords **MAY**, **MUST**, **MUST NOT**, **OPTIONAL**, **RECOMMENDED**, **REQUIRED**, **SHOULD**, and **SHOULD NOT**
+in this document are to be interpreted as described in BCP 14 [RFC2119](#rfc2119) [RFC8174](#rfc8174) when, and only
+when, they appear in all capitals, as shown here.
+
+To prove conformity:
+
+- Events **MUST** conform to the CloudEvents v1+ specification
+- Events **MUST** be serializable in JSON format
+- Events **MUST** include all REQUIRED attributes as defined in section 2.1
+- JSON schemas for event formats **MUST** be provided for validation
+
+### 1.3 Terminology
+
+> *This section is non-normative*
+
+**Event**: A data record expressing an occurrence and its context
+
+**Producer**: The system or process that creates events
+
+**Consumer**: The system or process that receives and processes events
+
+**Source**: An identifier for the context in which an event occurred
+
+**Type**: A string describing the nature of the event
+
+**CloudEvents**: The CNCF specification for describing events in a common format
+
+## 2 Event Specification
+
+> *This section is normative*
+
+### 2.1 Base Event Structure
+
+All events conforming to this standard **MUST** be valid CloudEvents v1.0.2 events [CloudEvents](#cloudevents).
+
+#### 2.1.1 Required Attributes
+
+The following CloudEvents attributes are **REQUIRED**:
+
+| Attribute     | Type          | Description                                                                                                   |
+|---------------|---------------|---------------------------------------------------------------------------------------------------------------|
+| `id`          | String        | Unique identifier for the event. Producers MUST ensure that `source` + `id` is unique for each distinct event |
+| `source`      | URI-reference | The source DID                                                                                                |
+| `specversion` | String        | CloudEvents specification version. MUST be "1.0"                                                              |
+| `type`        | String        | Event type identifier. MUST be a non-empty string. SHOULD use reverse-DNS notation                            |
+
+#### 2.1.2 Required Extension Attributes
+
+| Attribute   | Type   | Description    |
+|-------------|--------|----------------|
+| `sourcebpn` | String | The source BPN |
+
+#### 2.1.3 Recommended Attributes
+
+The following CloudEvents attributes are **RECOMMENDED**:
+
+| Attribute         | Type      | Description                                               |
+|-------------------|-----------|-----------------------------------------------------------|
+| `time`            | Timestamp | [RFC3339](#rfc3339) timestamp of when the event occurred  |
+| `datacontenttype` | String    | Media type of the data payload (e.g., "application/json") |
+| `dataschema`      | URI       | URI identifying the schema of the data payload            |
+
+If `datacontenttype` is not specified, the event **MUST** be interpreted as `application/json`.
+
+#### 2.1.4 Optional Attributes
+
+| Attribute          | Type   | Description                                             |
+|--------------------|--------|---------------------------------------------------------|
+| `subject`          | String | Subject of the event in the context of the event source |
+| `relatedmessageid` | String | A related message id                                    |
+
+### 2.2 Identifier Requirements
+
+Event IDs **MUST** be unique within the scope of a `source`:
+
+- Combination of `source` + `id` **MUST** uniquely identify an event
+- Duplicate events (e.g., retries) **MUST** reuse the same `source` and `id`
+- Event IDs **MUST** be UUIDs as defined by [RFC9562](#rfc9562)
+
+> NOTE: Consumers **MUST NOT** assume which UUID version a given `id` uses. The `id` is to be treated as an opaque
+> identifier and used only for equality comparison; its internal structure (version, timestamp, or any other embedded
+> data) **MUST NOT** be interpreted.
+
+### 2.3 Event Types
+
+#### 2.3.1 Type Naming Convention
+
+> ISSUE: We should consider using the `org.tractus-x` domain instead of `org.catena-x` for event types. This may
+> make the event types and specification more generic for reuse across other dataspaces.
+
+Event types **MUST** follow reverse-DNS notation where the domain is `org.catena-x`:
+
+`<domain>.<use case>.<specifier>.<version>`
+
+The `domain` and `use case` **MUST** be in lowercase.
+
+The `specifier` **MUST** be in Camel Case, for example:
+
+```
+org.catena-x.pcf.NotificationEvent.v1
+```
+
+#### 2.3.2 Type Versioning
+
+Version information **MUST** be encoded as follows:
+
+`v<major>`
+
+for example `v1`. Minor/patch versions **MUST NOT** be in the type name
+
+### 2.4 Event Data
+
+#### 2.4.1 Data Payload
+
+The `data` attribute **MAY** contain domain-specific information of a valid JSON type (object, array, string, number,
+boolean, null). The `data` attribute **SHOULD** have a schema defined via the `dataschema` attribute.
+
+#### 2.4.2 Data Content Type
+
+When `data` is present, `datacontenttype` **SHOULD** be specified. If specified, it **MUST** be a valid media type as
+defined by [RFC2046](#rfc2046). If `data` is present and `datacontenttype` is not specified, implementation **MUST** default to
+interpreting the data payload as "application/json". If `data_base64` is present and `datacontenttype` is not specified,
+implementation **MUST** default to interpreting the data payload as "application/octet-stream".
+
+### 2.5 Extension Attributes
+
+#### 2.5.1 Defining Extensions
+
+Custom attributes **MAY** be added following CloudEvents naming rules:
+
+- The attribute **MUST** consist of lowercase letters (a-z) or digits (0–9)
+- The attribute **MUST** be at least one character, **SHOULD NOT** exceed 20 characters
+- The attribute **SHOULD** start with a letter
+- The attribute **MUST NOT** use the name `data`, `data_base64`, or any CloudEvents reserved attribute names
+
+#### 2.5.2 Extension Attribute Types
+
+Extension attributes **MUST** use CloudEvents type system:
+
+- Boolean
+- Integer
+- String
+- Binary
+- URI
+- URI-reference
+- Timestamp
+
+## 3 Data Formats
+
+> *This section is normative*
+
+### 3.1 JSON Format
+
+All implementations **MUST** support JSON serialization per the CloudEvents JSON format specification
+[CloudEvents-JSON](#cloudevents-json).
+
+#### 3.2 JSON Schema
+
+JSON Schema for base CloudEvents structure using non-binary data:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "specversion",
+    "type",
+    "source",
+    "id"
+  ],
+  "properties": {
+    "specversion": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "type": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "string",
+      "format": "uri-reference",
+      "minLength": 1
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "datacontenttype": {
+      "type": "string"
+    },
+    "dataschema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "subject": {
+      "type": "string",
+      "minLength": 1
+    },
+    "data": {}
+  },
+  "additionalProperties": true
+}
+```
+
+## 4 HTTPS Binding
+
+CloudEvents **MUST** follow the HTTP Protocol Binding for CloudEvents [CloudEvents-HTTP](#cloudevents-http).
+
+When using HTTPS and non-binary content, events **MUST** be serialized in JSON format using the JSON structured mode.
+
+Batch events **MAY** be used.
+
+### 4.1 Security and Authorization
+
+All endpoints **MUST** use HTTPS, HTTP over TLS 1.2 or higher. Authorization **MUST** adhere to the Data Plane Signaling
+Token Refresh Protocol [DPS-TokenRefresh](#dps-token-refresh).
+
+If a client is not authorized for an endpoint request, the API **MUST** return `401 Unauthorized` or `404 Not Found`.
+
+## 5 Examples
+
+> *This section is non-normative*
+
+### 5.1 Single Event
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.pcf.NotificationEvent.v1",
+  "id": "e678a546-8bb7-4491-8765-046fa39ac76c",
+  "source": "did:web:example.com",
+  "sourcebpn": "BPNL0000000000AA",
+  "time": "2025-02-27T12:34:56.789Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://example.com/schemas/status.json",
+  "subject": "part/12345",
+  "data": {
+    "partId": "12345",
+    "status": "ready"
+  }
+}
+```
+
+### 5.2 Batch Event
+
+```json
+[
+  {
+    "specversion": "1.0",
+    "type": "org.catena-x.pcf.NotificationEvent.v1",
+    "id": "e678a546-8bb7-4491-8765-046fa39ac76c",
+    "source": "did:web:example.com",
+    "sourcebpn": "BPNL0000000000AA",
+    "time": "2025-02-27T12:34:56.789Z",
+    "datacontenttype": "application/json",
+    "dataschema": "https://example.com/schemas/status.json",
+    "subject": "part/12345",
+    "data": {
+      "partId": "12345",
+      "status": "ready"
+    }
+  },
+  {
+    "specversion": "1.0",
+    "type": "org.catena-x.pcf.NotificationEvent.v1",
+    "id": "2b51c8ed-2f06-4220-a454-52bd3d1b4797",
+    "source": "did:web:example.com",
+    "sourcebpn": "BPNL0000000000AA",
+    "time": "2025-02-27T12:34:56.789Z",
+    "datacontenttype": "application/json",
+    "dataschema": "https://example.com/schemas/status.json",
+    "subject": "part/67890",
+    "data": {
+      "partId": "67890",
+      "status": "updated"
+    }
+  }
+]
+```
+
+## 6 References
+
+### 6.1 Normative References
+
+<a id="cloudevents"></a>
+**[CloudEvents]** Cloud Native Computing Foundation, "CloudEvents 1.0.2 — Core Specification",
+<https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md>.
+
+<a id="cloudevents-http"></a>
+**[CloudEvents-HTTP]** Cloud Native Computing Foundation, "HTTP Protocol Binding for CloudEvents 1.0.2",
+<https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/bindings/http-protocol-binding.md>.
+
+<a id="cloudevents-json"></a>
+**[CloudEvents-JSON]** Cloud Native Computing Foundation, "JSON Event Format for CloudEvents 1.0.2",
+<https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/json-format.md>.
+
+<a id="dps-token-refresh"></a>
+**[DPS-TokenRefresh]** Eclipse Data Plane Signaling Working Group, "Data Plane Signaling Token Refresh Protocol",
+<https://github.com/eclipse-dataplane-signaling/dataplane-signaling>.
+
+<a id="rfc2046"></a>
+**[RFC2046]** Freed, N. and Borenstein, N., "Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types",
+RFC 2046, November 1996, <https://www.rfc-editor.org/rfc/rfc2046>.
+
+<a id="rfc2119"></a>
+**[RFC2119]** Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997,
+<https://www.rfc-editor.org/rfc/rfc2119>.
+
+<a id="rfc3339"></a>
+**[RFC3339]** Klyne, G. and Newman, C., "Date and Time on the Internet: Timestamps", RFC 3339, July 2002,
+<https://www.rfc-editor.org/rfc/rfc3339>.
+
+<a id="rfc3986"></a>
+**[RFC3986]** Berners-Lee, T., Fielding, R., and Masinter, L., "Uniform Resource Identifier (URI): Generic Syntax",
+STD 66, RFC 3986, January 2005, <https://www.rfc-editor.org/rfc/rfc3986>.
+
+<a id="rfc8174"></a>
+**[RFC8174]** Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, May 2017,
+<https://www.rfc-editor.org/rfc/rfc8174>.
+
+<a id="rfc9562"></a>
+**[RFC9562]** Davis, K., Peabody, B., and Leach, P., "Universally Unique IDentifiers (UUIDs)", RFC 9562, May 2024,
+<https://www.rfc-editor.org/rfc/rfc9562>.
+
+### 6.2 Non-Normative References
+
+<a id="cloudevents-primer"></a>
+**[CloudEvents-Primer]** Cloud Native Computing Foundation, "CloudEvents Primer",
+<https://github.com/cloudevents/spec/blob/main/cloudevents/primer.md>.

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement-CloudEvents-jim.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement-CloudEvents-jim.md
@@ -1,0 +1,1279 @@
+# CX-0135 Business Partner Company Certificate Management (CCM)
+
+## 1 Introduction
+
+This specification builds upon [CX-0151](#cx-0151) to define a Company Certificate Management (CCM) wire protocol for
+exchanging company certificate data between Catena-X participants.
+
+### 1.1 Conformance and Proof Of Conformity
+
+The keywords **MAY**, **MUST**, **MUST NOT**, **OPTIONAL**, **RECOMMENDED**, **REQUIRED**, **SHOULD**, and **SHOULD
+NOT** in this document are to be interpreted as described in BCP 14 [RFC2119](#rfc2119) [RFC8174](#rfc8174) when, and
+only when they appear in all capitals, as shown here.
+
+## 2 Model
+
+> *This section is NOT normative*
+
+This section describes the conceptual model underpinning the specification wire protocol. It is background material: the
+model introduces the entities and lifecycle that the normative sections build upon, but defines no normative
+requirements of its own.
+
+The model consists of two concepts:
+
+- The `Certificate Exchange` ([Section 2.1](#21-certificate-exchange)) — a single, correlatable interaction in which one
+  certificate is delivered from a Certificate Provider to a Certificate Consumer and its outcome is reported back. A
+  `Certificate Exchange` has its own identity and a well-defined lifecycle.
+- The `Certificate Lifecycle` ([Section 2.2](#22-certificate-lifecycle)) — the independent lifecycle of a certificate as
+  an artifact (its creation, modification, and revocation).
+
+### 2.1 Certificate Exchange
+
+A `Certificate Exchange` represents one end-to-end interaction between a Certificate Provider and a Certificate Consumer
+involving the delivery of a single certificate from the time the interaction is started until it reaches a terminal
+outcome.
+
+#### 2.1.1 Identity and Correlation
+
+A `Certificate Exchange` is identified by an **`exchangeId`** assigned when it is started. The `exchangeId` is the
+correlation handle for the entire interaction and is distinct from the identifier of any individual message or event
+(for example, a CloudEvent `id` + `source`).
+
+An exchange concerns a specific certificate, a (`certificateId`, `version`) pair, and is conducted with a
+`counterparty`, the authenticated Certificate Consumer.
+
+A `Certificate Exchange` may be opened by the Certificate Consumer or Certificate Provider:
+
+- **Consumer-initiated (pull):** the Certificate Consumer opens the exchange by requesting a certificate. The
+  Certificate Provider assigns the `exchangeId` (together with the `certificateId` and `version`) and returns them in
+  the response. Every request opens an exchange — including one the provider declines synchronously, which opens an
+  exchange that terminates immediately at `DECLINED`; the identifiers are still returned so the outcome remains
+  correlatable.
+- **Provider-initiated (push):** the Certificate Provider opens the exchange when a certificate is already available,
+  assigning an `exchangeId` and carrying it — with the `certificateId` and `version` — in the notification.
+
+**Idempotency.** Each `Certificate Exchange` has a unique `exchangeId`. A message that repeats an `exchangeId` refers to
+the same exchange rather than opening a new one. Multiple exchanges **MAY** concern the same certificate and
+`counterparty`.
+
+Acceptance feedback is correlated to the exchange by its `exchangeId` for both flows.
+
+A re-attempt after a terminal outcome — for example, re-evaluating a `REJECTED` or `ERRORED` certificate — is a new
+`Certificate Exchange`, with a new `exchangeId`, for the same certificate.
+
+#### 2.1.2 Phases and Ownership
+
+A `Certificate Exchange` progresses through two sequential phases, each owned by one party:
+
+1. **Fulfillment (Provider-owned):** The Certificate Provider works to make the certificate available.
+2. **Acceptance (Consumer-owned):** The Certificate Consumer retrieves and processes the certificate and reports the
+   outcome.
+
+The phases never overlap: the `Acceptance` phase begins only once `Fulfillment` has made the certificate available.
+Provider-owned and Consumer-owned states use deliberately disjoint vocabulary, so the owner of a state is unambiguous.
+Each phase can end in a negative decision or a business error: `DECLINED`/`REJECTED` are decisions (the provider
+declines the request, or the consumer does not accept the certificate), while `FAILED`/`ERRORED` indicate a business
+error such as an invalid certificate. These error states represent business-level problems only; technical and transport
+failures (for example, connectivity errors or timeouts) are not modeled as `Certificate Exchange` states and are handled
+at the transport layer.
+
+#### 2.1.3 State Machine
+
+The states of a `Certificate Exchange` are defined below and use the past tense:
+
+```mermaid
+stateDiagram-v2
+    [*] --> REQUESTED
+    REQUESTED --> ACKNOWLEDGED: provider accepts & starts preparing
+    REQUESTED --> DECLINED: provider declines the request
+    ACKNOWLEDGED --> CERTIFICATION_REQUESTED: submitted to external authority
+    ACKNOWLEDGED --> FULFILLED: certificate available (already held)
+    ACKNOWLEDGED --> FAILED: cannot produce a valid certificate
+    CERTIFICATION_REQUESTED --> FULFILLED: certified & available
+    CERTIFICATION_REQUESTED --> DECLINED: authority declines
+    CERTIFICATION_REQUESTED --> FAILED: certification invalid
+    FULFILLED --> RETRIEVED: consumer reports retrieval (OPTIONAL)
+    FULFILLED --> ACCEPTED: consumer accepts
+    FULFILLED --> REJECTED: consumer does not accept content
+    FULFILLED --> ERRORED: certificate invalid
+    RETRIEVED --> ACCEPTED: consumer accepts
+    RETRIEVED --> REJECTED: consumer does not accept content
+    RETRIEVED --> ERRORED: certificate invalid
+    DECLINED --> [*]
+    FAILED --> [*]
+    ACCEPTED --> [*]
+    REJECTED --> [*]
+    ERRORED --> [*]
+```
+
+| State                     | Phase / Owner          | Terminal | Description                                                                                                       |
+|---------------------------|------------------------|----------|-------------------------------------------------------------------------------------------------------------------|
+| `REQUESTED`               | Fulfillment / Provider | No       | The exchange was opened by the consumer; the provider has not yet acted. *(Consumer-initiated exchanges only.)*   |
+| `ACKNOWLEDGED`            | Fulfillment / Provider | No       | The provider accepted the request and began preparing the certificate.                                            |
+| `CERTIFICATION_REQUESTED` | Fulfillment / Provider | No       | The provider submitted the request to an external certification authority and is awaiting issuance. *(Optional.)* |
+| `FULFILLED`               | Fulfillment / Provider | No       | The certificate is prepared and available for retrieval. Hand-off point.                                          |
+| `DECLINED`                | Fulfillment / Provider | Yes      | The provider declined the request (a business decision; e.g. the certificate type is not offered).                |
+| `FAILED`                  | Fulfillment / Provider | Yes      | The provider could not produce a valid certificate (a business error; e.g. the certificate is invalid).           |
+| `RETRIEVED`               | Acceptance / Consumer  | No       | The consumer fetched the certificate and is processing it. *(Optional — see the note below.)*                      |
+| `ACCEPTED`                | Acceptance / Consumer  | Yes      | The consumer accepted the certificate.                                                                            |
+| `REJECTED`                | Acceptance / Consumer  | Yes      | The consumer did not accept the certificate content (a business decision).                                        |
+| `ERRORED`                 | Acceptance / Consumer  | Yes      | The consumer found the certificate to be in error (a business error; e.g. the certificate is invalid).            |
+
+A provider-initiated (push) exchange enters the lifecycle directly at `FULFILLED`. There is no request, so `REQUESTED`,
+`ACKNOWLEDGED` and `CERTIFICATION_REQUESTED` are never visited. The Acceptance phase is identical for both pull and
+push.
+
+`RETRIEVED` is **OPTIONAL**. It is a non-terminal acknowledgment that the consumer has fetched the certificate and is
+evaluating it; the consumer **MAY** report it as a delivery receipt but is not required to. An exchange therefore reaches
+a terminal acceptance state either by way of `RETRIEVED` (`FULFILLED → RETRIEVED → {ACCEPTED, REJECTED, ERRORED}`) or
+directly from `FULFILLED` (`FULFILLED → {ACCEPTED, REJECTED, ERRORED}`). The terminal acceptance verdicts remain
+Consumer-owned in both cases.
+
+`REQUESTED` is instantaneous and internal to the Certificate Provider; it is never reported on the wire. The first
+Fulfillment status a Certificate Consumer observes is the one carried in the request response (see
+[Section 4.4.1](#441-certificate-request)), which is `ACKNOWLEDGED` or a later state. A provider that can satisfy a
+request without intermediate steps **MAY** report a later Fulfillment state directly — for example `FULFILLED` when the
+certificate is already held, or `CERTIFICATION_REQUESTED` when the request is immediately forwarded to an external
+authority — having passed through the earlier states instantaneously. A reported `status` therefore reflects the
+exchange's current state, not necessarily a single transition from the one before it.
+
+#### 2.1.4 Terminal States and Immutability
+
+A `Certificate Exchange` is single-shot. The five terminal states — `DECLINED`, `FAILED`, `ACCEPTED`, `REJECTED`, and
+`ERRORED` — conclude the exchange permanently. A terminal exchange is never reopened, reused, or transitioned further.
+
+#### 2.1.5 Relationship to the Certificate Lifecycle
+
+A `Certificate Exchange` governs the *delivery* of a certificate, not the certificate itself. Modifications, updates,
+and revocations of a certificate are changes to the certificate artifact and are **not** transitions of a
+`Certificate Exchange`. In particular, a change to a certificate that has already been delivered does not reopen or
+alter the (possibly terminal) exchange that delivered it. A modification revises the certificate in place under the same
+`certificateId` and does not open a new `Certificate Exchange`. The certificate's own lifecycle is described in
+[Section 2.2](#22-certificate-lifecycle).
+
+### 2.2 Certificate Lifecycle
+
+The `Certificate Lifecycle` tracks a certificate as an artifact over time, independently of how many times it is
+delivered. Whereas a `Certificate Exchange` is single-shot and concerns one delivery interaction, a certificate is
+long-lived: it may be published, revised, and eventually withdrawn.
+
+#### 2.2.1 Identity and Versioning
+
+A certificate is identified by a **`certificateId`** that is stable for the life of the certificate. A modification does
+not create a new identifier; instead, the certificate carries a **`version`**:
+
+- `CREATED` makes the first `version` of the certificate available for retrieval.
+- Each `MODIFIED` publishes a new `version` under the same `certificateId`, superseding the previous one. The latest
+  `version` is authoritative.
+- A certificate is therefore identified by the pair (`certificateId`, `version`). A `Certificate Exchange` delivers one
+  specific `version`.
+
+The `certificateId` and the initial `version` number may be assigned before the certificate is published. When a
+Certificate Provider accepts a consumer's request and produces the certificate only later (see
+[Section 2.1.1](#211-identity-and-correlation)), the identifier is allocated at acceptance so that an in-progress
+`Certificate Exchange` can reference its certificate. Publication (`CREATED`) then occurs when the certificate becomes
+available.
+
+A certificate covers a **fixed set of locations** (`locationBpns`) — the BPNs it applies to. The location set is a
+static property of the certificate; a certificate that would cover a different set of locations is a distinct
+certificate.
+
+#### 2.2.2 State Machine
+
+The states use the past tense and describe the *publication* lifecycle of the certificate. They are independent of the
+certificate's validity (see [Section 2.2.3](#223-validity-as-a-separate-dimension)).
+
+```mermaid
+stateDiagram-v2
+    [*] --> CREATED
+    CREATED --> MODIFIED: new version published
+    MODIFIED --> MODIFIED: subsequent version published
+    CREATED --> WITHDRAWN: provider withdraws the certificate
+    MODIFIED --> WITHDRAWN: provider withdraws the certificate
+    WITHDRAWN --> [*]
+```
+
+| State       | Terminal | Description                                                                                                               |
+|-------------|----------|---------------------------------------------------------------------------------------------------------------------------|
+| `CREATED`   | No       | The certificate was first published under a new `certificateId`, establishing its initial `version`.                      |
+| `MODIFIED`  | No       | A new `version` of the certificate was published under the same `certificateId`; the `version` is incremented. May recur. |
+| `WITHDRAWN` | Yes      | The provider withdrew (removed) the certificate; it is no longer available. Terminal.                                     |
+
+#### 2.2.3 Validity as a Separate Dimension
+
+A certificate's validity is an independent dimension derived from its `validFrom` and `validUntil` dates, not from the
+publication states defined above. A given `version` is *active* within its validity window and *expired* afterward, and
+this status changes with the passage of time alone — no lifecycle transition occurs. The two dimensions are orthogonal:
+a certificate may be `WITHDRAWN` while still within its validity window, or remain `CREATED`/`MODIFIED`after it has
+expired.
+
+#### 2.2.4 Relationship to the `Certificate Exchange`
+
+Of the publication events, only `CREATED` may open a new `Certificate Exchange` — pushed by the provider, or discovered
+and requested by the consumer — to deliver the certificate. `MODIFIED` and `WITHDRAWN` do not open an exchange: a
+modification revises the certificate in place under the same `certificateId` without initiating a new delivery, and a
+withdrawal ends the certificate's availability. Consistent with
+[Section 2.1.5](#215-relationship-to-the-certificate-lifecycle), a lifecycle transition never alters an existing
+`Certificate Exchange`. These transitions are communicated to Certificate Consumers as certificate lifecycle events (see
+[Section 4.3.1](#431-certificate-lifecycle-events)).
+
+## 3 Data Plane Wire Protocol
+
+> *This section is NOT normative*
+
+This specification defines the following agent systems:
+
+- **Certificate Consumer Control Plane (Cert CCP)**: The [DSP](#dsp) Control Plane operated by the participant that
+  consumes certificates.
+- **Certificate Consumer Data Plane (Cert CDP)**: The [DSP](#dsp) Data Plane operated by the participant that consumes
+  certificates.
+- **Certificate Provider Control Plane (Cert PCP)**: The [DSP](#dsp) Control Plane operated by the participant that
+  provides certificates.
+- **Certificate Provider Data Plane (Cert PDP)**: The [DSP](#dsp) Data Plane operated by the participant that provides
+  certificates.
+
+The wire transmission protocol supports an optional consumer endpoint for providers to send notifications of certificate
+availability. Provider endpoints offer mechanisms for requesting, querying, retrieving, and reporting the status of
+certificates. The endpoints are discoverable and made accessible via a [DSP Catalog](#dsp-catalog).
+
+```mermaid
+sequenceDiagram
+    participant CDP as Cert CDP
+    participant CCP as Cert CCP
+    participant PCP as Cert PCP
+    participant PDP as Cert PDP
+
+    rect rgb(208, 208, 209, .5)
+        PCP --> CCP: 1. Negotiate event API contract (DSP)
+        PDP ->> CDP: 2. Certificate lifecycle event (Created / Modified / Withdrawn)
+    end
+    CCP --> PCP: 3. Negotiate or reuse cert API contract (DSP)
+    CDP ->> PDP: 4. Request cert (returns exchangeId + certificateId + version)
+    CDP ->> PDP: 5. Poll fulfillment status (ACKNOWLEDGED, CERTIFICATION_REQUESTED, FULFILLED, DECLINED, FAILED)
+    PDP ->> CDP: 5a. (optional) Push fulfillment status to Notification API
+    CDP ->> PDP: 6. Retrieve cert
+    CDP ->> PDP: 7. Acceptance status (RETRIEVED, ACCEPTED, REJECTED, ERRORED)
+```             
+
+### 3.1 Certificate Notification
+
+A Certificate Consumer may optionally make a [Certificate Consumer Notification API](#43-certificate-consumer-notification-api)
+available to Certificate Providers. Through it, a provider may notify the consumer of certificate lifecycle changes
+(creation, modification, and withdrawal) and may push the fulfillment status of an open consumer-initiated exchange
+instead of requiring the consumer to poll (see [Section 4.3.2](#432-certificate-fulfillment-notification)). This API
+functions as a DSP Data Plane, which Certificate Providers gain access to via the DSP protocol. Upon receiving a
+lifecycle notification with `status` `CREATED` or `MODIFIED`, the Certificate Consumer may retrieve the certificate
+using the [Certificate Provider API](#44-certificate-provider-api).
+
+### 3.2 Certificate Retrieval
+
+A Certificate Consumer retrieves a certificate using the [Certificate Provider API](#44-certificate-provider-api). This API functions as a DSP Data
+Plane, which Certificate Consumers gain access to via the DSP protocol. The Certificate Consumer may request a
+certificate, poll the fulfillment status of a request, query for certificates, get a certificate's metadata, retrieve
+its individual documents, and post acceptance status updates.
+
+## 4 Data Plane Wire Protocol APIs
+
+> *This section is normative*
+
+### 4.1 Base URL and Transport Security
+
+The <base> notation indicates the base URL for all HTTPS endpoints. For example, if the base URL is api.example.com, the
+URL https://<base>/certificates/123 will map to https//api.example.com/certificates/123.
+
+All endpoints **MUST** use HTTPS, HTTP over TLS 1.2 or higher.
+
+### 4.2 Authorization
+
+Authorization **MUST** adhere to [CX-0000 Section 4](./CX-0000-CloudEventsFoundation-jim.md#4-https-binding).
+
+### 4.3 Certificate Consumer Notification API
+
+The Certificate Consumer Notification API enables a Certificate Consumer to receive notifications from Certificate
+Providers: certificate lifecycle events (see [Section 4.3.1](#431-certificate-lifecycle-events)) and fulfillment-status
+updates for its open exchanges (see [Section 4.3.2](#432-certificate-fulfillment-notification)). This API is optional; a Certificate
+Consumer that does not wish to receive notifications is not required to implement it. A Certificate Consumer that does
+implement it **MUST** adhere to the normative requirements defined in this section.
+
+#### 4.3.1 Certificate Lifecycle Events
+
+The Certificate Consumer **MUST** expose the following endpoint to receive certificate lifecycle events. These events
+are sent by the Certificate Provider to notify the Certificate Consumer of changes to a certificate over its lifecycle
+(see [Section 2.2](#22-certificate-lifecycle)).
+
+|                  |                                                      |
+|------------------|------------------------------------------------------|
+| **HTTP Method**: | POST                                                 |
+| **URL Path**     | `POST /certificate-notifications`                    |
+| **Content Type** | `application/cloudevents+json`                       |
+| **Request**      | `CertificateLifecycleStatus` (single event or batch) |
+| **Response**     | `HTTP 204` with empty body or error                  |
+
+The endpoint accepts a single CloudEvent ([CloudEvents](#cloudevents)) or a batch (a JSON array) as defined in
+[CX-0000](#cx-0000), whose HTTP binding follows [CloudEvents-HTTP](#cloudevents-http).
+
+**Event Type**: `org.catena-x.ccm.CertificateLifecycleStatus.v1`
+
+The Certificate Consumer **MUST** dispatch on the `data.status` value, which maps to a state of the
+`Certificate Lifecycle`:
+
+| `status`    | Lifecycle State | Opens an Exchange | Description                                                                                                                  |
+|-------------|-----------------|-------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `CREATED`   | `CREATED`       | Yes               | A certificate has been published and is available for retrieval.                                                             |
+| `MODIFIED`  | `MODIFIED`      | No                | A new `version` of an existing certificate has been published; the Certificate Consumer **MAY** retrieve the latest version. |
+| `WITHDRAWN` | `WITHDRAWN`     | No                | The certificate has been withdrawn and is no longer available.                                                               |
+
+Only the `CREATED` status opens a `Certificate Exchange` (see
+[Section 2.2.4](#224-relationship-to-the-certificate-exchange)); `MODIFIED` and `WITHDRAWN` are notifications that do
+not open an exchange. The two state machines meet here: a `CREATED` lifecycle event opens a provider-initiated exchange
+that enters directly at the `FULFILLED` exchange state (see [Section 2.1.3](#213-state-machine)) — both express that the
+certificate is now available, from the artifact and delivery viewpoints respectively.
+
+The `data` payload derives from the common certificate-status base payload and constrains `status` to the lifecycle
+values above. It contains the following properties:
+
+| Property          | Type             | Required    | Description                                                                                                                                                                                                       |
+|-------------------|------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`      | String           | CONDITIONAL | Identifier of the `Certificate Exchange` opened by this event. Present when `status` is `CREATED`; absent for `MODIFIED` and `WITHDRAWN`. Distinct from the CloudEvent `id`.                                      |
+| `certificateId`   | String           | MANDATORY   | The unique identifier of the certificate, used to retrieve the certificate via `GET /certificates/{id}`.                                                                                                          |
+| `version`         | Integer          | MANDATORY   | The version of the certificate. Together with `certificateId` it identifies the specific certificate (see [Section 2.2.1](#221-identity-and-versioning)).                                                         |
+| `status`          | String           | MANDATORY   | The lifecycle status. **MUST** be one of `CREATED`, `MODIFIED`, or `WITHDRAWN`.                                                                                                                                   |
+| `datasetId`       | String           | MANDATORY   | The identifier of the DSP dataset under which the certificate is exposed in the Certificate Provider's catalog.                                                                                                   |
+| `certificateType` | String           | MANDATORY   | An opaque string identifying the certificate type (for example, `ISO9001`).                                                                                                                                       |
+| `validFrom`       | String           | CONDITIONAL | The inclusive start date of the validity period, an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`). **MUST** be present when `status` is `CREATED` or `MODIFIED`; **MAY** be omitted when `status` is `WITHDRAWN`. |
+| `validUntil`      | String           | CONDITIONAL | The inclusive end date of the validity period, an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`). Same presence rules as `validFrom`.                                                                              |
+| `locationBpns`    | Array of Strings | OPTIONAL    | The Business Partner Numbers (BPNs) of the sites or addresses the certificate applies to. If omitted, the certificate applies to the issuing legal entity as a whole.                                             |
+
+The following are non-normative examples.
+
+**Status: CREATED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+  "time": "2025-05-04T07:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "version": 1,
+    "status": "CREATED",
+    "datasetId": "dataset-ccm-cert-abc123",
+    "certificateType": "ISO9001",
+    "validFrom": "2023-01-25",
+    "validUntil": "2026-01-24",
+    "locationBpns": [
+      "BPNS00000003AYRE",
+      "BPNA000000000001"
+    ]
+  }
+}
+```
+
+**Status: MODIFIED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e",
+  "time": "2025-08-01T07:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json",
+  "data": {
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "version": 2,
+    "status": "MODIFIED",
+    "datasetId": "dataset-ccm-cert-abc123",
+    "certificateType": "ISO9001",
+    "validFrom": "2023-01-25",
+    "validUntil": "2027-01-24",
+    "locationBpns": [
+      "BPNS00000003AYRE",
+      "BPNA000000000001"
+    ]
+  }
+}
+```
+
+**Status: WITHDRAWN**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "c3d4e5f6-7a8b-9c0d-1e2f-3a4b5c6d7e8f",
+  "time": "2025-09-01T07:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json",
+  "data": {
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "version": 2,
+    "status": "WITHDRAWN",
+    "datasetId": "dataset-ccm-cert-abc123",
+    "certificateType": "ISO9001"
+  }
+}
+```
+
+**Batch**
+
+Multiple events **MAY** be delivered in a single request as a JSON array:
+
+```json
+[
+  {
+    "specversion": "1.0",
+    "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+    "source": "urn:bpn:BPNL0000000001AB",
+    "subject": "BPNL0000000002CD",
+    "id": "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+    "time": "2025-05-04T07:00:00Z",
+    "datacontenttype": "application/json",
+    "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json",
+    "data": {
+      "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+      "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+      "version": 1,
+      "status": "CREATED",
+      "datasetId": "dataset-ccm-cert-abc123",
+      "certificateType": "ISO9001",
+      "validFrom": "2023-01-25",
+      "validUntil": "2026-01-24"
+    }
+  },
+  {
+    "specversion": "1.0",
+    "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+    "source": "urn:bpn:BPNL0000000001AB",
+    "subject": "BPNL0000000002CD",
+    "id": "d4e5f6a7-8b9c-0d1e-2f3a-4b5c6d7e8f90",
+    "time": "2025-09-01T07:00:00Z",
+    "datacontenttype": "application/json",
+    "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json",
+    "data": {
+      "certificateId": "cert-770e8400-e29b-41d4-a716-446655449999",
+      "version": 3,
+      "status": "WITHDRAWN",
+      "datasetId": "dataset-ccm-cert-xyz789",
+      "certificateType": "ISO14001"
+    }
+  }
+]
+```
+
+#### 4.3.2 Certificate Fulfillment Notification
+
+When a Certificate Consumer exposes this Notification API, a Certificate Provider **MAY** push the Fulfillment status of
+an open consumer-initiated exchange (see [Section 4.4.1](#441-certificate-request)) to the consumer instead of requiring
+it to poll (see [Section 4.4.2](#442-certificate-request-status)). This is the push counterpart of that poll and is
+particularly useful for long-running fulfillment, for example while a certificate is `CERTIFICATION_REQUESTED`.
+
+The event is delivered to the same `POST /certificate-notifications` endpoint defined in
+[Section 4.3.1](#431-certificate-lifecycle-events) and is distinguished by its CloudEvents `type`. It is correlated to the
+exchange by the `exchangeId` carried in `data`; the `exchangeId` is the one the Certificate Provider returned when the
+exchange was opened (see [Section 4.4.1](#441-certificate-request)).
+
+This notification reports only the Fulfillment phase. It is independent of the certificate's lifecycle status: a
+`FULFILLED` notification reports that the requested exchange has been fulfilled and the certificate is available for
+retrieval, whereas a lifecycle `CREATED` event (see [Section 4.3.1](#431-certificate-lifecycle-events)) reports a
+provider-initiated exchange. A Certificate Provider **MUST NOT** use a lifecycle event to report the outcome of a
+consumer-initiated request.
+
+**Event Type**: `org.catena-x.ccm.CertificateFulfillmentStatus.v1`
+
+The `data` payload contains the following properties:
+
+| Property        | Type            | Required    | Description                                                                                                                 |
+|-----------------|-----------------|-------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`    | String          | MANDATORY   | Identifier of the `Certificate Exchange` whose Fulfillment status is reported. Distinct from the CloudEvent `id`.           |
+| `certificateId` | String          | MANDATORY   | The unique identifier of the certificate the exchange concerns.                                                             |
+| `status`        | String          | MANDATORY   | The Fulfillment status. **MUST** be one of `ACKNOWLEDGED`, `CERTIFICATION_REQUESTED`, `FULFILLED`, `DECLINED`, or `FAILED`. |
+| `errors`        | Array of Object | CONDITIONAL | A list of error details. **MUST** be present and non-empty when `status` is `DECLINED` or `FAILED`.                         |
+
+A Certificate Provider that pushes Fulfillment status **SHOULD** send at least the terminal outcomes (`FULFILLED`,
+`DECLINED`, `FAILED`); intermediate states **MAY** also be pushed. Each entry in the `errors` array contains the
+properties defined in [Section 4.4.5](#445-certificate-acceptance-events).
+
+The following are non-normative examples.
+
+**Status: FULFILLED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateFulfillmentStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "f0e1d2c3-b4a5-6789-0abc-def012345678",
+  "time": "2025-05-04T07:30:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-fulfillment-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "FULFILLED"
+  }
+}
+```
+
+**Status: DECLINED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateFulfillmentStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "a1c2e3f4-5b6d-7e8f-9a0b-1c2d3e4f5a6b",
+  "time": "2025-05-04T07:30:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-fulfillment-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "DECLINED",
+    "errors": [
+      {
+        "message": "Certificate type not offered for the requested location"
+      }
+    ]
+  }
+}
+```
+
+#### 4.3.3 Certificate Acceptance Status Query
+
+The Certificate Consumer **MUST** expose the following endpoint to allow a Certificate Provider to query the current
+acceptance status of a `Certificate Exchange` it opened.
+
+|                  |                                                     |
+|------------------|-----------------------------------------------------|
+| **HTTP Method**: | GET                                                 |
+| **URL Path**     | `GET /certificate-acceptance-status/{id}`           |
+| **Content Type** | `application/json`                                  |
+| **Response**     | `CertificateAcceptanceStatusResponse` or `HTTP 404` |
+
+The `{id}` path parameter **MUST** be the `exchangeId` assigned by the Certificate Provider when the exchange was opened
+(see [Section 2.1.1](#211-identity-and-correlation)). If the `exchangeId` is unknown to the Certificate Consumer, the
+endpoint **MUST** respond with `HTTP 404`.
+
+If the Certificate Consumer has not yet concluded processing, the endpoint **MAY** return a
+`CertificateAcceptanceStatusResponse` whose `status` is `RETRIEVED`.
+
+The response body **MUST** be a JSON object representing the current acceptance status of the exchange. The `status`
+property conveys the Acceptance-phase state, including the non-terminal value `RETRIEVED` indicating that the
+certificate has been retrieved but acceptance has not yet concluded. The `errors` follow the same rules as the
+corresponding acceptance event in [Section 4.4.5](#445-certificate-acceptance-events).
+
+| Property        | Type            | Required  | Description                                                                                                                                                              |
+|-----------------|-----------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`    | String          | MANDATORY | The identifier of the `Certificate Exchange`. Matches the `{id}` path parameter of the request.                                                                          |
+| `certificateId` | String          | MANDATORY | The unique identifier of the certificate the status applies to.                                                                                                          |
+| `status`        | String          | MANDATORY | The current acceptance status. **MUST** be one of `RETRIEVED`, `ACCEPTED`, `REJECTED`, or `ERRORED`.                                                                     |
+| `errors`        | Array of Object | OPTIONAL  | A list of error details. **MUST NOT** be present when `status` is `RETRIEVED` or `ACCEPTED`. **MUST** be present and non-empty when `status` is `REJECTED` or `ERRORED`. |
+
+Each entry in the `errors` array contains the same properties as defined in
+[Section 4.4.5](#445-certificate-acceptance-events):
+
+| Property    | Type   | Required  | Description                                                                                                                                                  |
+|-------------|--------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `message`   | String | MANDATORY | A human-readable description of the error.                                                                                                                   |
+| `specifier` | String | OPTIONAL  | An identifier scoping the error to a particular element of the certificate, such as a site BPN. If omitted, the error applies to the certificate as a whole. |
+
+The following are non-normative examples of acceptance status responses:
+
+**Status: RETRIEVED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "status": "RETRIEVED"
+}
+```
+
+**Status: ACCEPTED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "status": "ACCEPTED"
+}
+```
+
+**Status: REJECTED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "status": "REJECTED",
+  "errors": [
+    {
+      "message": "Certificate has expired"
+    },
+    {
+      "specifier": "BPNS000000000002",
+      "message": "Site BPNS000000000002 has been Rejected"
+    }
+  ]
+}
+```
+
+#### 4.3.4 OpenAPI Specification
+
+The Certificate Consumer Notification API is formally defined by the OpenAPI document
+[certificate-consumer-notification-api-jim.yaml](./certificate-consumer-notification-api-jim.yaml).
+
+#### 4.3.5 DSP Dataset Representation
+
+The Certificate Consumer **MUST** expose a dataset according to the Dataspace Protocol (DSP) specification in their
+catalog. This dataset **MUST** include the following properties:
+
+|                 |                                                                                                                                           |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| **conformsTo**: | The Dublin Core [conformsTo](#dcmi-conformsto) property. The value must be set to `https://w3id.org/catenax/certificate-notification-api` |
+
+The catalog distribution **MUST** have its `format` value set to `https://w3id.org/dps/http-pull`.
+
+> TODO: Note this section is dependent on the following issues:
+> - [DPS-99](#dps-99)
+
+The following is a non-normative example of a consumer catalog dataset:
+
+```json
+{
+  "@id": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
+  "@type": "Dataset",
+  "hasPolicy": [],
+  "conformsTo": "https://w3id.org/catenax/certificate-notification-api",
+  "distribution": [
+    {
+      "@type": "Distribution",
+      "format": "https://w3id.org/dps/http-pull",
+      "accessService": "urn:uuid:4aa2dcc8-4d2d-569e-d634-8394a8834d77"
+    }
+  ]
+}
+```
+
+### 4.4 Certificate Provider API
+
+> *This section is normative*
+
+The Certificate Provider API enables Certificate Providers to accept certificate requests, report request fulfillment
+status, serve certificate data, answer certificate queries, and receive acceptance status from Certificate Consumers.
+
+#### 4.4.1 Certificate Request
+
+The Certificate Provider **MUST** expose the following endpoint to allow a Certificate Consumer to request a
+certificate. A request opens a consumer-initiated `Certificate Exchange` (see [Section 2.1](#21-certificate-exchange)).
+
+|                  |                                                       |
+|------------------|-------------------------------------------------------|
+| **HTTP Method**: | POST                                                  |
+| **URL Path**     | `POST /certificate-requests`                          |
+| **Content Type** | `application/json`                                    |
+| **Request**      | `CertificateRequest`                                  |
+| **Response**     | `HTTP 202` with `CertificateRequestResponse` or error |
+
+The request body **MUST** be a JSON object containing the following properties:
+
+| Property          | Type             | Required  | Description                                                                                                                                |
+|-------------------|------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `certificateType` | String           | MANDATORY | An opaque string identifying the certificate type to be requested (for example, `ISO9001`).                                                |
+| `locationBpns`    | Array of Strings | OPTIONAL  | The Business Partner Numbers (BPNs) of the sites or addresses the request applies to. If omitted, the request applies to the legal entity. |
+
+When the Certificate Provider accepts the request, it **MUST** assign an `exchangeId`, `certificateId`, and `version`
+and return them in the response, so the Certificate Consumer can correlate the exchange, poll its fulfillment status,
+and later retrieve the certificate. The response body **MUST** be a JSON object containing the following properties:
+
+| Property        | Type            | Required  | Description                                                                                                                           |
+|-----------------|-----------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`    | String          | MANDATORY | The identifier assigned to the opened `Certificate Exchange`. Used to poll status ([Section 4.4.2](#442-certificate-request-status)). |
+| `certificateId` | String          | MANDATORY | The identifier assigned to the requested certificate. Used to retrieve it via `GET /certificates/{id}`.                               |
+| `version`       | Integer         | MANDATORY | The version assigned to the requested certificate.                                                                                    |
+| `status`        | String          | MANDATORY | The fulfillment status of the request. **MUST** be one of `ACKNOWLEDGED`, `CERTIFICATION_REQUESTED`, `FULFILLED`, or `DECLINED`.      |
+| `errors`        | Array of Object | OPTIONAL  | A list of error details. **MUST** be present and non-empty when `status` is `DECLINED`.                                               |
+
+The `status` reflects the Fulfillment phase of the exchange (see [Section 2.1.3](#213-state-machine)). A Certificate
+Provider that already holds the requested certificate **MAY** return `FULFILLED` immediately. A Certificate Provider
+that will not satisfy the request **MAY** return `DECLINED` with errors, or respond with `HTTP 400` if the request is
+malformed. Each entry in the `errors` array contains the properties defined in
+[Section 4.4.5](#445-certificate-acceptance-events).
+
+The following is a non-normative example of a certificate request:
+
+```json
+{
+  "certificateType": "ISO9001",
+  "locationBpns": [
+    "BPNS00000003AYRE"
+  ]
+}
+```
+
+The following is a non-normative example of a response (`HTTP 202`):
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "version": 1,
+  "status": "ACKNOWLEDGED"
+}
+```
+
+#### 4.4.2 Certificate Request Status
+
+The Certificate Provider **MUST** expose the following endpoint to allow a Certificate Consumer to poll the fulfillment
+status of a request previously submitted via [Section 4.4.1](#441-certificate-request).
+
+|                  |                                          |
+|------------------|------------------------------------------|
+| **HTTP Method**: | GET                                      |
+| **URL Path**     | `GET /certificate-requests/{id}`         |
+| **Content Type** | `application/json`                       |
+| **Response**     | `CertificateRequestStatus` or `HTTP 404` |
+
+The `{id}` path parameter **MUST** be the `exchangeId` returned by the Certificate Provider in the response to the
+certificate request. If the `exchangeId` is unknown to the Certificate Provider, the endpoint **MUST** respond with
+`HTTP 404`.
+
+The response body **MUST** be a JSON object containing the following properties:
+
+| Property        | Type            | Required  | Description                                                                                                                         |
+|-----------------|-----------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`    | String          | MANDATORY | The identifier of the `Certificate Exchange`. Matches the `{id}` path parameter of the request.                                     |
+| `certificateId` | String          | MANDATORY | The unique identifier of the requested certificate.                                                                                 |
+| `version`       | Integer         | MANDATORY | The version of the requested certificate.                                                                                           |
+| `status`        | String          | MANDATORY | The current fulfillment status. **MUST** be one of `ACKNOWLEDGED`, `CERTIFICATION_REQUESTED`, `FULFILLED`, `DECLINED`, or `FAILED`. |
+| `errors`        | Array of Object | OPTIONAL  | A list of error details. **MUST** be present and non-empty when `status` is `DECLINED` or `FAILED`.                                 |
+
+When the `status` is `FULFILLED`, the certificate is available and **MAY** be retrieved via
+[Section 4.4.3](#443-certificate-retrieval). This endpoint reports only the Fulfillment phase; the Certificate
+Consumer's acceptance outcome is reported separately via [Section 4.4.5](#445-certificate-acceptance-events).
+
+Polling is not the only way to learn the Fulfillment status. If the Certificate Consumer exposes the Certificate
+Consumer Notification API, a Certificate Provider **MAY** instead push these status updates to it as they occur (see
+[Section 4.3.2](#432-certificate-fulfillment-notification)), in which case the consumer need not poll. The two mechanisms
+are equivalent and carry the same `exchangeId` and `status`.
+
+The following are non-normative examples of request status responses:
+
+**Status: ACKNOWLEDGED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "version": 1,
+  "status": "ACKNOWLEDGED"
+}
+```
+
+**Status: FULFILLED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "version": 1,
+  "status": "FULFILLED"
+}
+```
+
+**Status: DECLINED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "version": 1,
+  "status": "DECLINED",
+  "errors": [
+    {
+      "message": "Certificate type not offered for the requested location"
+    }
+  ]
+}
+```
+
+#### 4.4.3 Certificate Retrieval
+
+The Certificate Provider **MUST** expose the following endpoint to retrieve certificate metadata.
+
+|                  |                                           |
+|------------------|-------------------------------------------|
+| **HTTP Method**: | GET                                       |
+| **URL Path**     | `GET /certificates/{id}`                  |
+| **Query**        | `version` (OPTIONAL) — defaults to latest |
+| **Content Type** | `application/json`                        |
+| **Response**     | `HTTP 200` with metadata JSON or error    |
+
+The response is a JSON object ([RFC8259](#rfc8259)) describing the certificate. The certificate is metadata only; the
+binary documents are **not** included. Each associated document is listed by reference in the `documents` array and
+retrieved independently via [Section 4.4.4](#444-document-retrieval).
+
+If an error occurs, the Certificate Provider **MUST** set the `Content-Type` to `application/json` and return an error
+body encoded as `application/json` ([RFC8259](#rfc8259)).
+
+By default, the endpoint returns the latest `version`. A consumer **MAY** request a specific version with the `version`
+query parameter (for example, `GET /certificates/{id}?version=2`) — for instance, to retrieve the exact version a
+`Certificate Exchange` concerns. The Certificate Provider **MUST** be able to return any version that is still
+referenced by a non-terminal `Certificate Exchange`; whether other superseded versions remain retrievable is at the
+provider's discretion.
+
+Each version references a set of documents through the `documents` array. Document identity is independent of the
+certificate version: a `documentId` is stable and its content is immutable. A document that does not change across
+versions is therefore referenced by the same `documentId` in each version that includes it.
+
+The metadata is a JSON object containing the following properties:
+
+| Property          | Type             | Required  | Description                                                                                                                                                           |
+|-------------------|------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `certificateId`   | String           | MANDATORY | The unique identifier of the certificate. Matches the `{id}` path parameter of the request.                                                                           |
+| `version`         | Integer          | MANDATORY | The version returned — the version requested via the `version` query parameter, or the latest version if none was specified.                                          |
+| `certificateType` | String           | MANDATORY | An opaque string identifying the certificate type (for example, `ISO9001`).                                                                                           |
+| `validFrom`       | String           | MANDATORY | The inclusive start date of the certificate validity period, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`).                                           |
+| `validUntil`      | String           | MANDATORY | The inclusive end date of the certificate validity period, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`).                                             |
+| `locationBpns`    | Array of Strings | OPTIONAL  | The Business Partner Numbers (BPNs) of the sites or addresses the certificate applies to. If omitted, the certificate applies to the issuing legal entity as a whole. |
+| `documents`       | Array of Objects | OPTIONAL  | The documents associated with this certificate version, each a `CertificateDocument` object (see below). If omitted or empty, the version has no associated documents. |
+
+Each `CertificateDocument` object contains the following properties:
+
+| Property     | Type   | Required  | Description                                                                                                                                                  |
+|--------------|--------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `documentId` | String | MANDATORY | The opaque, version-independent identifier of the document, used to retrieve it via `GET /documents/{id}` (see [Section 4.4.4](#444-document-retrieval)).     |
+| `mediaType`  | String | MANDATORY | The IANA media type of the document binary (for example, `application/pdf` or `image/png`).                                                                  |
+
+The following is a non-normative example of a response:
+
+```json
+{
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "version": 1,
+  "certificateType": "ISO9001",
+  "validFrom": "2023-01-25",
+  "validUntil": "2026-01-24",
+  "locationBpns": [
+    "BPNS00000003AYRE",
+    "BPNA000000000001"
+  ],
+  "documents": [
+    {
+      "documentId": "doc-3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "mediaType": "application/pdf"
+    }
+  ]
+}
+```
+
+#### 4.4.4 Document Retrieval
+
+The Certificate Provider **MUST** expose the following endpoint to retrieve a certificate document by its identifier.
+
+|                  |                                              |
+|------------------|----------------------------------------------|
+| **HTTP Method**: | GET                                          |
+| **URL Path**     | `GET /documents/{id}`                        |
+| **Content Type** | The document's `mediaType`                   |
+| **Response**     | `HTTP 200` with the document binary or error |
+
+A document is identified by an opaque `documentId` that is independent of any certificate version (see
+[Section 4.4.3](#443-certificate-retrieval)). Because a document's identity and content are stable, the same document
+**MAY** be referenced by multiple certificate versions, and the endpoint therefore requires no `version` parameter.
+
+The response body is the document binary, served directly with the `Content-Type` set to the document's `mediaType`
+(for example, `application/pdf`) as advertised in the certificate metadata
+([Section 4.4.3](#443-certificate-retrieval)).
+
+If an error occurs, the Certificate Provider **MUST** set the `Content-Type` to `application/json` and return an error
+body encoded as `application/json` ([RFC8259](#rfc8259)).
+
+The following is a non-normative example of a response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/pdf
+
+[binary document data]
+```
+
+#### 4.4.5 Certificate Acceptance Events
+
+The Certificate Provider **MUST** expose the following endpoint to receive certificate acceptance status from the
+Certificate Consumer. The status is delivered as a `CertificateAcceptanceStatus` CloudEvent.
+
+|                  |                                                       |
+|------------------|-------------------------------------------------------|
+| **HTTP Method**: | POST                                                  |
+| **URL Path**     | `POST /certificate-acceptance-notifications`          |
+| **Content Type** | `application/cloudevents+json`                        |
+| **Request**      | `CertificateAcceptanceStatus` (single event or batch) |
+| **Response**     | `HTTP 204` with empty body or error                   |
+
+The endpoint accepts a single CloudEvent ([CloudEvents](#cloudevents)) or a batch (a JSON array) as defined in
+[CX-0000](#cx-0000), whose HTTP binding follows [CloudEvents-HTTP](#cloudevents-http).
+
+**Event Type**: `org.catena-x.ccm.CertificateAcceptanceStatus.v1`
+
+The Certificate Provider **MUST** dispatch on the `data.status` value, which is a state of the Acceptance phase (see
+[Section 2.1.3](#213-state-machine)). The event is correlated to its `Certificate Exchange` by the `exchangeId` carried
+in `data` (see [Section 2.1.1](#211-identity-and-correlation)).
+
+Acceptance status **MUST** reference an existing `Certificate Exchange`. Acceptance is the Consumer-owned phase of an
+exchange, so it can only be reported when an exchange is present — one opened by a consumer request
+([Section 4.4.1](#441-certificate-request)) or by a provider notification
+([Section 4.3.1](#431-certificate-lifecycle-events)). Merely retrieving a certificate (for example, after
+a [query](#446-certificate-query)) does **not** establish an exchange and therefore does not permit acceptance feedback.
+If the `exchangeId` is unknown to the Certificate Provider, it **MUST** reject the event with `HTTP 404`.
+
+Reporting `RETRIEVED` is **OPTIONAL** (see [Section 2.1.3](#213-state-machine)). It is a non-terminal delivery
+acknowledgment; a Certificate Consumer **MAY** report it after fetching the certificate, or **MAY** proceed directly to
+a terminal acceptance status (`ACCEPTED`, `REJECTED`, or `ERRORED`) without first reporting `RETRIEVED`. A Certificate
+Provider **MUST NOT** require a prior `RETRIEVED` event as a precondition for accepting a terminal acceptance status.
+
+The `data` payload derives from the common certificate-status base payload and constrains `status` to the acceptance
+values below. It contains the following properties:
+
+| Property        | Type            | Required    | Description                                                                                                                                                              |
+|-----------------|-----------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`    | String          | MANDATORY   | Identifier of the `Certificate Exchange` this event reports on. Distinct from the CloudEvent `id`.                                                                       |
+| `certificateId` | String          | MANDATORY   | The unique identifier of the certificate the status applies to.                                                                                                          |
+| `status`        | String          | MANDATORY   | The acceptance status of the certificate. **MUST** be one of `RETRIEVED`, `ACCEPTED`, `REJECTED`, or `ERRORED`.                                                          |
+| `errors`        | Array of Object | CONDITIONAL | A list of error details. **MUST NOT** be present when `status` is `RETRIEVED` or `ACCEPTED`. **MUST** be present and non-empty when `status` is `REJECTED` or `ERRORED`. |
+
+Each entry in the `errors` array contains the following properties:
+
+| Property    | Type   | Required  | Description                                                                                                                                                  |
+|-------------|--------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `message`   | String | MANDATORY | A human-readable description of the error.                                                                                                                   |
+| `specifier` | String | OPTIONAL  | An identifier scoping the error to a particular element of the certificate, such as a site BPN. If omitted, the error applies to the certificate as a whole. |
+
+The following are non-normative examples.
+
+**Status: RETRIEVED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateAcceptanceStatus.v1",
+  "source": "urn:bpn:BPNL0000000002CD",
+  "subject": "BPNL0000000001AB",
+  "id": "e9f8d7c6-b5a4-9382-7160-5a4b3c2d1e0f",
+  "time": "2025-05-04T08:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "RETRIEVED"
+  }
+}
+```
+
+**Status: ACCEPTED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateAcceptanceStatus.v1",
+  "source": "urn:bpn:BPNL0000000002CD",
+  "subject": "BPNL0000000001AB",
+  "id": "a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d",
+  "time": "2025-05-04T09:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "ACCEPTED"
+  }
+}
+```
+
+**Status: REJECTED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateAcceptanceStatus.v1",
+  "source": "urn:bpn:BPNL0000000002CD",
+  "subject": "BPNL0000000001AB",
+  "id": "f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c",
+  "time": "2025-05-04T09:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "REJECTED",
+    "errors": [
+      {
+        "message": "Certificate has expired"
+      },
+      {
+        "message": "Unexpected data format"
+      },
+      {
+        "specifier": "BPNS000000000002",
+        "message": "Site BPNS000000000002 has been Rejected"
+      }
+    ]
+  }
+}
+```
+
+**Status: ERRORED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateAcceptanceStatus.v1",
+  "source": "urn:bpn:BPNL0000000002CD",
+  "subject": "BPNL0000000001AB",
+  "id": "c8d7e6f5-a4b3-2109-8765-432109fedcba",
+  "time": "2025-05-04T08:30:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "ERRORED",
+    "errors": [
+      {
+        "message": "Certificate document is malformed and cannot be validated"
+      }
+    ]
+  }
+}
+```
+
+#### 4.4.6 Certificate Query
+
+The Certificate Provider **MUST** expose the following endpoint to query certificates.
+
+|                  |                            |
+|------------------|----------------------------|
+| **HTTP Method**: | POST                       |
+| **URL Path**     | `POST /certificates/search` |
+| **Content Type** | `application/json`         |
+| **Request**      | `CertificateQuery`         |
+| **Response**     | `CertificateQueryResponse` |
+
+The request body **MUST** be a JSON object containing the query criteria. The `limit` property **MAY** be included to
+indicate the maximum number of results to return per page. If omitted, the Certificate Provider **MAY** apply a default
+limit.
+
+The `CertificateQuery` object contains the following properties:
+
+| Property          | Type    | Required  | Description                                                                                                                                                                                              |
+|-------------------|---------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `certificateType` | String  | MANDATORY | An opaque string identifying the certificate type to be matched (for example, `ISO9001`).                                                                                                                |
+| `from`            | String  | OPTIONAL  | The inclusive lower bound of the certificate validity range, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`). Only certificates whose `validFrom` is on or after this date are returned.   |
+| `to`              | String  | OPTIONAL  | The inclusive upper bound of the certificate validity range, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`). Only certificates whose `validUntil` is on or before this date are returned. |
+| `limit`           | Integer | OPTIONAL  | The maximum number of results to return in a single page. If omitted, the Certificate Provider **MAY** apply a default limit.                                                                            |
+
+The following is a non-normative example of a certificate query:
+
+```json
+{
+  "certificateType": "ISO9001",
+  "from": "2023-01-25",
+  "to": "2026-01-24",
+  "limit": 50
+}
+```
+
+The response body **MUST** be a JSON array of `CertificateQueryResponse` objects containing match results. Each object
+contains the following properties:
+
+| Property          | Type             | Required  | Description                                                                                                                                                           |
+|-------------------|------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `certificateId`   | String           | MANDATORY | The unique identifier of the certificate, used to retrieve the certificate via `GET /certificates/{id}`.                                                              |
+| `version`         | Integer          | MANDATORY | The latest version of the certificate.                                                                                                                                |
+| `datasetId`       | String           | MANDATORY | The identifier of the DSP dataset under which the certificate is exposed in the Certificate Provider's catalog.                                                       |
+| `certificateType` | String           | MANDATORY | An opaque string identifying the certificate type (for example, `ISO9001`).                                                                                           |
+| `validFrom`       | String           | MANDATORY | The inclusive start date of the certificate validity period, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`).                                           |
+| `validUntil`      | String           | MANDATORY | The inclusive end date of the certificate validity period, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`).                                             |
+| `locationBpns`    | Array of Strings | OPTIONAL  | The Business Partner Numbers (BPNs) of the sites or addresses the certificate applies to. If omitted, the certificate applies to the issuing legal entity as a whole. |
+| `documents`       | Array of Objects | OPTIONAL  | The documents associated with the returned certificate version, each a `CertificateDocument` object as defined in [Section 4.4.3](#443-certificate-retrieval). Retrieved via `GET /documents/{id}`. |
+
+The following is a non-normative example of a certificate query response containing an array of
+`CertificateQueryResponse` objects:
+
+```json
+[
+  {
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "version": 1,
+    "datasetId": "dataset-ccm-cert-abc123",
+    "certificateType": "ISO9001",
+    "validFrom": "2023-01-25",
+    "validUntil": "2026-01-24",
+    "locationBpns": [
+      "BPNS00000003AYRE",
+      "BPNA000000000001"
+    ],
+    "documents": [
+      {
+        "documentId": "doc-3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "mediaType": "application/pdf"
+      }
+    ]
+  }
+]
+```
+
+##### 4.4.6.1 Pagination
+
+Implementations **MAY** paginate the results of a query. When results are paginated, pagination data **MUST** be
+conveyed using Web Linking as defined in [RFC8288](#rfc8288) via the HTTP `Link` response header. Only the `next`
+and `prev` link relation types **MUST** be supported; implementations **MAY** include additional relation types such as
+`first` and `last`.
+
+Each value in the `Link` header **MUST** be enclosed in angle brackets and **MUST** include a `rel` parameter
+identifying the link relation type. When more than one link is present, values **MUST** be comma-separated as defined
+in [RFC8288, Section 3](#rfc8288). The target URL **MUST** refer to the
+`POST /certificates/search` endpoint of the Certificate Provider. The content and structure of the URL (including any
+query parameters or opaque page tokens used to encode pagination state) are not defined by this specification and
+clients **MUST** treat them as opaque.
+
+To retrieve the next or previous page, a client **MUST** issue a `POST` request to the URL provided in the corresponding
+`Link` header value, using the same request body as the original query. The `Link` header **MUST NOT** be included in
+responses that are not paginated, and a `next` or `prev` link **MUST** be omitted when no further results are available
+in that direction.
+
+The following is a non-normative example of a paginated response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Link: <https://provider.example.com/certificates/search?cursor=eyJvZmZzZXQiOjUwfQ>; rel="next",
+      <https://provider.example.com/certificates/search?cursor=eyJvZmZzZXQiOjB9>; rel="prev"
+
+[
+  {
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "version": 1,
+    "datasetId": "dataset-ccm-cert-abc123",
+    "certificateType": "ISO9001",
+    "validFrom": "2023-01-25",
+    "validUntil": "2026-01-24",
+    "locationBpns": [
+      "BPNS00000003AYRE",
+      "BPNA000000000001"
+    ]
+  }
+]
+```
+
+#### 4.4.7 OpenAPI Specification
+
+The Certificate Provider API is formally defined by the OpenAPI document
+[certificate-provider-api-jim.yaml](./certificate-provider-api-jim.yaml).
+
+#### 4.4.8 DSP Dataset Representation
+
+The Certificate Provider **MUST** expose a dataset according to the Dataspace Protocol (DSP) specification in their
+catalog. This dataset **MUST** include the following properties:
+
+|                 |                                                                                                                              |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------|
+| **conformsTo**: | The Dublin Core [conformsTo](#dcmi-conformsto) property. The value must be set to `https://w3id.org/catenax/certificate-api` |
+
+The catalog distribution **MUST** have its `format` value set to `https://w3id.org/dps/http-pull`.
+
+> TODO: Note this section is dependent on the following issues:
+> - [DPS-98](#dps-98)
+> - [DPS-99](#dps-99)
+
+The following is a non-normative example of a provider catalog dataset:
+
+```json
+{
+  "@id": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
+  "@type": "Dataset",
+  "hasPolicy": [],
+  "conformsTo": "https://w3id.org/catenax/certificate-api",
+  "distribution": [
+    {
+      "@type": "Distribution",
+      "format": "https://w3id.org/dps/http-pull",
+      "accessService": "urn:uuid:4aa2dcc8-4d2d-569e-d634-8394a8834d77"
+    }
+  ]
+}
+```                              
+
+## 5 References
+
+### 5.1 Normative References
+
+<a id="cx-0000"></a>
+**[CX-0000]** Catena-X, "CloudEventsFoundation",
+[CX-0000-CloudEventsFoundation.md](./CX-0000-CloudEventsFoundation-jim.md).
+
+<a id="cx-0151"></a>
+**[CX-0151]** Catena-X, "Industry Core: Part Type and Part Instance".
+
+<a id="cloudevents"></a>
+**[CloudEvents]** Cloud Native Computing Foundation, "CloudEvents 1.0.2 — Core Specification",
+<https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md>.
+
+<a id="cloudevents-http"></a>
+**[CloudEvents-HTTP]** Cloud Native Computing Foundation, "HTTP Protocol Binding for CloudEvents 1.0.2",
+<https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/bindings/http-protocol-binding.md>.
+
+<a id="dcmi-conformsto"></a>
+**[DCMI-conformsTo]** Dublin Core Metadata Initiative, "DCMI Metadata Terms — conformsTo",
+<https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/conformsTo/>.
+
+<a id="dsp"></a>
+**[DSP]** Eclipse Dataspace Working Group, "Dataspace Protocol 2025-1",
+<https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1/>.
+
+<a id="iso8601"></a>
+**[ISO8601]** International Organization for Standardization, "ISO 8601-1:2019, Date and time — Representations for
+information interchange — Part 1: Basic rules", <https://www.iso.org/standard/70907.html>.
+
+<a id="rfc2119"></a>
+**[RFC2119]** Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997,
+<https://www.rfc-editor.org/rfc/rfc2119>.
+
+<a id="rfc8174"></a>
+**[RFC8174]** Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, May 2017,
+<https://www.rfc-editor.org/rfc/rfc8174>.
+
+<a id="rfc8259"></a>
+**[RFC8259]** Bray, T., Ed., "The JavaScript Object Notation (JSON) Data Interchange Format", STD 90, RFC 8259, December
+2017, <https://www.rfc-editor.org/rfc/rfc8259>.
+
+<a id="rfc8288"></a>
+**[RFC8288]** Nottingham, M., "Web Linking", RFC 8288, October 2017, <https://www.rfc-editor.org/rfc/rfc8288>.
+
+### 5.2 Non-Normative References
+
+<a id="dsp-catalog"></a>
+**[DSP-Catalog]** Eclipse Dataspace Working Group, "Dataspace Protocol 2025-1 — Catalog Protocol",
+<https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1/#catalog-protocol>.
+
+<a id="dps-98"></a>
+**[DPS-98]** Eclipse Data Plane Signaling, "Issue #98",
+<https://github.com/eclipse-dataplane-signaling/dataplane-signaling/issues/98>.
+
+<a id="dps-99"></a>
+**[DPS-99]** Eclipse Data Plane Signaling, "Issue #99",
+<https://github.com/eclipse-dataplane-signaling/dataplane-signaling/issues/99>.

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement-combined.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement-combined.md
@@ -1,0 +1,1582 @@
+---
+tags:
+  - CAT/Value Added Services
+---
+
+# CX-0135 Business Partner Company Certificate Management (CCM) v0.1.0
+
+## ABSTRACT
+
+In the world of business, company certificates are often mandatory for conducting transactions between two companies.
+However, the process of provisioning, maintaining, and validating these certificates can be a major challenge. For
+example, if a company has 100 customers, it may need to provide its company certificates in 100 different ways and
+maintain them at 100 different points.
+
+To address this, this standard defines a standardized but generic data model and a wire protocol for company
+certificates. It allows Catena-X participants to provide, request, accept, or reject company certificates across the
+dataspace, exchanging certificate data as [CloudEvents](#cloudevents) over the [Dataspace Protocol](#dsp).
+
+## FOR WHOM IS THE STANDARD DESIGNED
+
+This standard is relevant to the following parties:
+
+- Data Provider and Consumer
+- Business Application Provider
+
+It applies to business application providers who aim to offer a solution for managing and exchanging company
+certificates and returning them to customers, and to Data Providers and Consumers who manage and exchange certificates
+through such a business application.
+
+> **Context regarding the naming of involved parties:**
+> The Catena-X operating model and the [Dataspace Protocol](#dsp) use the roles `Data Consumer` and `Data Provider`,
+> defined in terms of which party offers and consumes a dataset. In some cases these align with the direction of
+> certificate flow, but — particularly for the certificate push mechanism — a mismatch can occur. To avoid ambiguity,
+> this standard uses the terms `Certificate Provider` and `Certificate Consumer` to designate the business entities,
+> independently of the data-plane roles they assume for a given interaction.
+
+## 1 Introduction
+
+This specification builds upon [CX-0151](#cx-0151) to define a Company Certificate Management (CCM) wire protocol for
+exchanging company certificate data between Catena-X participants.
+
+### 1.1 Conformance and Proof Of Conformity
+
+The keywords **MAY**, **MUST**, **MUST NOT**, **OPTIONAL**, **RECOMMENDED**, **REQUIRED**, **SHOULD**, and **SHOULD
+NOT** in this document are to be interpreted as described in BCP 14 [RFC2119](#rfc2119) [RFC8174](#rfc8174) when, and
+only when they appear in all capitals, as shown here.
+
+## 2 Model
+
+> *This section is NOT normative*
+
+This section describes the conceptual model underpinning the specification wire protocol. It is background material: the
+model introduces the entities and lifecycle that the normative sections build upon, but defines no normative
+requirements of its own.
+
+The model consists of two concepts:
+
+- The `Certificate Exchange` ([Section 2.1](#21-certificate-exchange)) — a single, correlatable interaction in which one
+  certificate is delivered from a Certificate Provider to a Certificate Consumer and its outcome is reported back. A
+  `Certificate Exchange` has its own identity and a well-defined lifecycle.
+- The `Certificate Lifecycle` ([Section 2.2](#22-certificate-lifecycle)) — the independent lifecycle of a certificate as
+  an artifact (its creation, modification, and revocation).
+
+### 2.1 Certificate Exchange
+
+A `Certificate Exchange` represents one end-to-end interaction between a Certificate Provider and a Certificate Consumer
+involving the delivery of a single certificate from the time the interaction is started until it reaches a terminal
+outcome.
+
+#### 2.1.1 Identity and Correlation
+
+A `Certificate Exchange` is identified by an **`exchangeId`** assigned when it is started. The `exchangeId` is the
+correlation handle for the entire interaction and is distinct from the identifier of any individual message or event
+(for example, a CloudEvent `id` + `source`).
+
+An exchange concerns a specific certificate, a (`certificateId`, `version`) pair, and is conducted with a
+`counterparty`, the authenticated Certificate Consumer.
+
+A `Certificate Exchange` may be opened by the Certificate Consumer or Certificate Provider:
+
+- **Consumer-initiated (pull):** the Certificate Consumer opens the exchange by requesting a certificate. The
+  Certificate Provider assigns the `exchangeId` (together with the `certificateId` and `version`) and returns them in
+  the response. Every request opens an exchange — including one the provider declines synchronously, which opens an
+  exchange that terminates immediately at `DECLINED`; the identifiers are still returned so the outcome remains
+  correlatable.
+- **Provider-initiated (push):** the Certificate Provider opens the exchange when a certificate is already available,
+  assigning an `exchangeId` and carrying it — with the `certificateId` and `version` — in the notification.
+
+**Idempotency.** Each `Certificate Exchange` has a unique `exchangeId`. A message that repeats an `exchangeId` refers to
+the same exchange rather than opening a new one. Multiple exchanges **MAY** concern the same certificate and
+`counterparty`.
+
+Acceptance feedback is correlated to the exchange by its `exchangeId` for both flows.
+
+A re-attempt after a terminal outcome — for example, re-evaluating a `REJECTED` or `ERRORED` certificate — is a new
+`Certificate Exchange`, with a new `exchangeId`, for the same certificate.
+
+#### 2.1.2 Phases and Ownership
+
+A `Certificate Exchange` progresses through two sequential phases, each owned by one party:
+
+1. **Fulfillment (Provider-owned):** The Certificate Provider works to make the certificate available.
+2. **Acceptance (Consumer-owned):** The Certificate Consumer retrieves and processes the certificate and reports the
+   outcome.
+
+The phases never overlap: the `Acceptance` phase begins only once `Fulfillment` has made the certificate available.
+Provider-owned and Consumer-owned states use deliberately disjoint vocabulary, so the owner of a state is unambiguous.
+Each phase can end in a negative decision or a business error: `DECLINED`/`REJECTED` are decisions (the provider
+declines the request, or the consumer does not accept the certificate), while `FAILED`/`ERRORED` indicate a business
+error such as an invalid certificate. These error states represent business-level problems only; technical and transport
+failures (for example, connectivity errors or timeouts) are not modeled as `Certificate Exchange` states and are handled
+at the transport layer.
+
+#### 2.1.3 State Machine
+
+The states of a `Certificate Exchange` are defined below and use the past tense:
+
+```mermaid
+stateDiagram-v2
+    [*] --> REQUESTED
+    REQUESTED --> ACKNOWLEDGED: provider accepts & starts preparing
+    REQUESTED --> DECLINED: provider declines the request
+    ACKNOWLEDGED --> CERTIFICATION_REQUESTED: submitted to external authority
+    ACKNOWLEDGED --> FULFILLED: certificate available (already held)
+    ACKNOWLEDGED --> FAILED: cannot produce a valid certificate
+    CERTIFICATION_REQUESTED --> FULFILLED: certified & available
+    CERTIFICATION_REQUESTED --> DECLINED: authority declines
+    CERTIFICATION_REQUESTED --> FAILED: certification invalid
+    FULFILLED --> RETRIEVED: consumer reports retrieval (OPTIONAL)
+    FULFILLED --> ACCEPTED: consumer accepts
+    FULFILLED --> REJECTED: consumer does not accept content
+    FULFILLED --> ERRORED: certificate invalid
+    RETRIEVED --> ACCEPTED: consumer accepts
+    RETRIEVED --> REJECTED: consumer does not accept content
+    RETRIEVED --> ERRORED: certificate invalid
+    DECLINED --> [*]
+    FAILED --> [*]
+    ACCEPTED --> [*]
+    REJECTED --> [*]
+    ERRORED --> [*]
+```
+
+| State                     | Phase / Owner          | Terminal | Description                                                                                                       |
+|---------------------------|------------------------|----------|-------------------------------------------------------------------------------------------------------------------|
+| `REQUESTED`               | Fulfillment / Provider | No       | The exchange was opened by the consumer; the provider has not yet acted. *(Consumer-initiated exchanges only.)*   |
+| `ACKNOWLEDGED`            | Fulfillment / Provider | No       | The provider accepted the request and began preparing the certificate.                                            |
+| `CERTIFICATION_REQUESTED` | Fulfillment / Provider | No       | The provider submitted the request to an external certification authority and is awaiting issuance. *(Optional.)* |
+| `FULFILLED`               | Fulfillment / Provider | No       | The certificate is prepared and available for retrieval. Hand-off point.                                          |
+| `DECLINED`                | Fulfillment / Provider | Yes      | The provider declined the request (a business decision; e.g. the certificate type is not offered).                |
+| `FAILED`                  | Fulfillment / Provider | Yes      | The provider could not produce a valid certificate (a business error; e.g. the certificate is invalid).           |
+| `RETRIEVED`               | Acceptance / Consumer  | No       | The consumer fetched the certificate and is processing it. *(Optional — see the note below.)*                      |
+| `ACCEPTED`                | Acceptance / Consumer  | Yes      | The consumer accepted the certificate.                                                                            |
+| `REJECTED`                | Acceptance / Consumer  | Yes      | The consumer did not accept the certificate content (a business decision).                                        |
+| `ERRORED`                 | Acceptance / Consumer  | Yes      | The consumer found the certificate to be in error (a business error; e.g. the certificate is invalid).            |
+
+A provider-initiated (push) exchange enters the lifecycle directly at `FULFILLED`. There is no request, so `REQUESTED`,
+`ACKNOWLEDGED` and `CERTIFICATION_REQUESTED` are never visited. The Acceptance phase is identical for both pull and
+push.
+
+`RETRIEVED` is **OPTIONAL**. It is a non-terminal acknowledgment that the consumer has fetched the certificate and is
+evaluating it; the consumer **MAY** report it as a delivery receipt but is not required to. An exchange therefore reaches
+a terminal acceptance state either by way of `RETRIEVED` (`FULFILLED → RETRIEVED → {ACCEPTED, REJECTED, ERRORED}`) or
+directly from `FULFILLED` (`FULFILLED → {ACCEPTED, REJECTED, ERRORED}`). The terminal acceptance verdicts remain
+Consumer-owned in both cases.
+
+`REQUESTED` is instantaneous and internal to the Certificate Provider; it is never reported on the wire. The first
+Fulfillment status a Certificate Consumer observes is the one carried in the request response (see
+[Section 4.4.1](#441-certificate-request)), which is `ACKNOWLEDGED` or a later state. A provider that can satisfy a
+request without intermediate steps **MAY** report a later Fulfillment state directly — for example `FULFILLED` when the
+certificate is already held, or `CERTIFICATION_REQUESTED` when the request is immediately forwarded to an external
+authority — having passed through the earlier states instantaneously. A reported `status` therefore reflects the
+exchange's current state, not necessarily a single transition from the one before it.
+
+#### 2.1.4 Terminal States and Immutability
+
+A `Certificate Exchange` is single-shot. The five terminal states — `DECLINED`, `FAILED`, `ACCEPTED`, `REJECTED`, and
+`ERRORED` — conclude the exchange permanently. A terminal exchange is never reopened, reused, or transitioned further.
+
+#### 2.1.5 Relationship to the Certificate Lifecycle
+
+A `Certificate Exchange` governs the *delivery* of a certificate, not the certificate itself. Modifications, updates,
+and revocations of a certificate are changes to the certificate artifact and are **not** transitions of a
+`Certificate Exchange`. In particular, a change to a certificate that has already been delivered does not reopen or
+alter the (possibly terminal) exchange that delivered it. A modification revises the certificate in place under the same
+`certificateId` and does not open a new `Certificate Exchange`. The certificate's own lifecycle is described in
+[Section 2.2](#22-certificate-lifecycle).
+
+### 2.2 Certificate Lifecycle
+
+The `Certificate Lifecycle` tracks a certificate as an artifact over time, independently of how many times it is
+delivered. Whereas a `Certificate Exchange` is single-shot and concerns one delivery interaction, a certificate is
+long-lived: it may be published, revised, and eventually withdrawn.
+
+#### 2.2.1 Identity and Versioning
+
+A certificate is identified by a **`certificateId`** that is stable for the life of the certificate. A modification does
+not create a new identifier; instead, the certificate carries a **`version`**:
+
+- `CREATED` makes the first `version` of the certificate available for retrieval.
+- Each `MODIFIED` publishes a new `version` under the same `certificateId`, superseding the previous one. The latest
+  `version` is authoritative.
+- A certificate is therefore identified by the pair (`certificateId`, `version`). A `Certificate Exchange` delivers one
+  specific `version`.
+
+The `certificateId` and the initial `version` number may be assigned before the certificate is published. When a
+Certificate Provider accepts a consumer's request and produces the certificate only later (see
+[Section 2.1.1](#211-identity-and-correlation)), the identifier is allocated at acceptance so that an in-progress
+`Certificate Exchange` can reference its certificate. Publication (`CREATED`) then occurs when the certificate becomes
+available.
+
+A certificate covers a **fixed set of locations** — the sites (BPNS) and addresses (BPNA) it applies to. On the full
+certificate record these are carried as structured `enclosedSites` (each with an optional per-location area of application;
+see [Section 4.4.3](#443-certificate-retrieval)); lighter projections such as query results and lifecycle events carry
+only the bare BPNs as `enclosedSiteBpns`. The location set is a static property of the certificate; a certificate that would
+cover a different set of locations is a distinct certificate.
+
+#### 2.2.2 State Machine
+
+The states use the past tense and describe the *publication* lifecycle of the certificate. They are independent of the
+certificate's validity (see [Section 2.2.3](#223-validity-as-a-separate-dimension)).
+
+```mermaid
+stateDiagram-v2
+    [*] --> CREATED
+    CREATED --> MODIFIED: new version published
+    MODIFIED --> MODIFIED: subsequent version published
+    CREATED --> WITHDRAWN: provider withdraws the certificate
+    MODIFIED --> WITHDRAWN: provider withdraws the certificate
+    WITHDRAWN --> [*]
+```
+
+| State       | Terminal | Description                                                                                                               |
+|-------------|----------|---------------------------------------------------------------------------------------------------------------------------|
+| `CREATED`   | No       | The certificate was first published under a new `certificateId`, establishing its initial `version`.                      |
+| `MODIFIED`  | No       | A new `version` of the certificate was published under the same `certificateId`; the `version` is incremented. May recur. |
+| `WITHDRAWN` | Yes      | The provider withdrew (removed) the certificate; it is no longer available. Terminal.                                     |
+
+#### 2.2.3 Validity as a Separate Dimension
+
+A certificate's validity is an independent dimension derived from its `validFrom` and `validUntil` dates, not from the
+publication states defined above. A given `version` is *active* within its validity window and *expired* afterward, and
+this status changes with the passage of time alone — no lifecycle transition occurs. The two dimensions are orthogonal:
+a certificate may be `WITHDRAWN` while still within its validity window, or remain `CREATED`/`MODIFIED`after it has
+expired.
+
+#### 2.2.4 Relationship to the `Certificate Exchange`
+
+Of the publication events, only `CREATED` may open a new `Certificate Exchange` — pushed by the provider, or discovered
+and requested by the consumer — to deliver the certificate. `MODIFIED` and `WITHDRAWN` do not open an exchange: a
+modification revises the certificate in place under the same `certificateId` without initiating a new delivery, and a
+withdrawal ends the certificate's availability. Consistent with
+[Section 2.1.5](#215-relationship-to-the-certificate-lifecycle), a lifecycle transition never alters an existing
+`Certificate Exchange`. These transitions are communicated to Certificate Consumers as certificate lifecycle events (see
+[Section 4.3.1](#431-certificate-lifecycle-events)).
+
+## 3 Data Plane Wire Protocol
+
+> *This section is NOT normative*
+
+This specification defines the following agent systems:
+
+- **Certificate Consumer Control Plane (Cert CCP)**: The [DSP](#dsp) Control Plane operated by the participant that
+  consumes certificates.
+- **Certificate Consumer Data Plane (Cert CDP)**: The [DSP](#dsp) Data Plane operated by the participant that consumes
+  certificates.
+- **Certificate Provider Control Plane (Cert PCP)**: The [DSP](#dsp) Control Plane operated by the participant that
+  provides certificates.
+- **Certificate Provider Data Plane (Cert PDP)**: The [DSP](#dsp) Data Plane operated by the participant that provides
+  certificates.
+
+The wire transmission protocol supports an optional consumer endpoint for providers to send notifications of certificate
+availability. Provider endpoints offer mechanisms for requesting, querying, retrieving, and reporting the status of
+certificates. The endpoints are discoverable and made accessible via a [DSP Catalog](#dsp-catalog).
+
+```mermaid
+sequenceDiagram
+    participant CDP as Cert CDP
+    participant CCP as Cert CCP
+    participant PCP as Cert PCP
+    participant PDP as Cert PDP
+
+    rect rgb(208, 208, 209, .5)
+        PCP --> CCP: 1. Negotiate event API contract (DSP)
+        PDP ->> CDP: 2. Certificate lifecycle event (Created / Modified / Withdrawn)
+    end
+    CCP --> PCP: 3. Negotiate or reuse cert API contract (DSP)
+    CDP ->> PDP: 4. Request cert (returns exchangeId + certificateId + version)
+    CDP ->> PDP: 5. Poll fulfillment status (ACKNOWLEDGED, CERTIFICATION_REQUESTED, FULFILLED, DECLINED, FAILED)
+    PDP ->> CDP: 5a. (optional) Push fulfillment status to Notification API
+    CDP ->> PDP: 6. Retrieve cert
+    CDP ->> PDP: 7. Acceptance status (RETRIEVED, ACCEPTED, REJECTED, ERRORED)
+```             
+
+### 3.1 Certificate Notification
+
+A Certificate Consumer may optionally make a [Certificate Consumer Notification API](#43-certificate-consumer-notification-api)
+available to Certificate Providers. Through it, a provider may notify the consumer of certificate lifecycle changes
+(creation, modification, and withdrawal) and may push the fulfillment status of an open consumer-initiated exchange
+instead of requiring the consumer to poll (see [Section 4.3.2](#432-certificate-fulfillment-notification)). This API
+functions as a DSP Data Plane, which Certificate Providers gain access to via the DSP protocol. Upon receiving a
+lifecycle notification with `status` `CREATED` or `MODIFIED`, the Certificate Consumer may retrieve the certificate
+using the [Certificate Provider API](#44-certificate-provider-api).
+
+### 3.2 Certificate Retrieval
+
+A Certificate Consumer retrieves a certificate using the [Certificate Provider API](#44-certificate-provider-api). This API functions as a DSP Data
+Plane, which Certificate Consumers gain access to via the DSP protocol. The Certificate Consumer may request a
+certificate, poll the fulfillment status of a request, query for certificates, get a certificate's metadata, retrieve
+its individual documents, and post acceptance status updates.
+
+## 4 Data Plane Wire Protocol APIs
+
+> *This section is normative*
+
+### 4.1 Base URL and Transport Security
+
+The <base> notation indicates the base URL for all HTTPS endpoints. For example, if the base URL is api.example.com, the
+URL https://<base>/certificates/123 will map to https//api.example.com/certificates/123.
+
+All endpoints **MUST** use HTTPS, HTTP over TLS 1.2 or higher.
+
+### 4.2 Authorization
+
+Authorization **MUST** adhere to [CX-0000 Section 4](./CX-0000-CloudEventsFoundation-combined.md#4-https-binding).
+
+### 4.3 Certificate Consumer Notification API
+
+The Certificate Consumer Notification API enables a Certificate Consumer to receive notifications from Certificate
+Providers: certificate lifecycle events (see [Section 4.3.1](#431-certificate-lifecycle-events)) and fulfillment-status
+updates for its open exchanges (see [Section 4.3.2](#432-certificate-fulfillment-notification)). This API is optional; a Certificate
+Consumer that does not wish to receive notifications is not required to implement it. A Certificate Consumer that does
+implement it **MUST** adhere to the normative requirements defined in this section.
+
+#### 4.3.1 Certificate Lifecycle Events
+
+The Certificate Consumer **MUST** expose the following endpoint to receive certificate lifecycle events. These events
+are sent by the Certificate Provider to notify the Certificate Consumer of changes to a certificate over its lifecycle
+(see [Section 2.2](#22-certificate-lifecycle)).
+
+|                  |                                                      |
+|------------------|------------------------------------------------------|
+| **HTTP Method**: | POST                                                 |
+| **URL Path**     | `POST /certificate-notifications`                    |
+| **Content Type** | `application/cloudevents+json`                       |
+| **Request**      | `CertificateLifecycleStatus` (single event or batch) |
+| **Response**     | `HTTP 204` with empty body or error                  |
+
+The endpoint accepts a single CloudEvent ([CloudEvents](#cloudevents)) or a batch (a JSON array) as defined in
+[CX-0000](#cx-0000), whose HTTP binding follows [CloudEvents-HTTP](#cloudevents-http).
+
+**Event Type**: `org.catena-x.ccm.CertificateLifecycleStatus.v1`
+
+The Certificate Consumer **MUST** dispatch on the `data.status` value, which maps to a state of the
+`Certificate Lifecycle`:
+
+| `status`    | Lifecycle State | Opens an Exchange | Description                                                                                                                  |
+|-------------|-----------------|-------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `CREATED`   | `CREATED`       | Yes               | A certificate has been published and is available for retrieval.                                                             |
+| `MODIFIED`  | `MODIFIED`      | No                | A new `version` of an existing certificate has been published; the Certificate Consumer **MAY** retrieve the latest version. |
+| `WITHDRAWN` | `WITHDRAWN`     | No                | The certificate has been withdrawn and is no longer available.                                                               |
+
+Only the `CREATED` status opens a `Certificate Exchange` (see
+[Section 2.2.4](#224-relationship-to-the-certificate-exchange)); `MODIFIED` and `WITHDRAWN` are notifications that do
+not open an exchange. The two state machines meet here: a `CREATED` lifecycle event opens a provider-initiated exchange
+that enters directly at the `FULFILLED` exchange state (see [Section 2.1.3](#213-state-machine)) — both express that the
+certificate is now available, from the artifact and delivery viewpoints respectively.
+
+The `data` payload derives from the common certificate-status base payload and constrains `status` to the lifecycle
+values above. It contains the following properties:
+
+| Property          | Type             | Required    | Description                                                                                                                                                                                                       |
+|-------------------|------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`      | String           | CONDITIONAL | Identifier of the `Certificate Exchange` opened by this event. Present when `status` is `CREATED`; absent for `MODIFIED` and `WITHDRAWN`. Distinct from the CloudEvent `id`.                                      |
+| `certificateId`   | String           | MANDATORY   | The unique identifier of the certificate, used to retrieve the certificate via `GET /certificates/{id}`.                                                                                                          |
+| `version`         | Integer          | MANDATORY   | The version of the certificate. Together with `certificateId` it identifies the specific certificate (see [Section 2.2.1](#221-identity-and-versioning)).                                                         |
+| `status`          | String           | MANDATORY   | The lifecycle status. **MUST** be one of `CREATED`, `MODIFIED`, or `WITHDRAWN`.                                                                                                                                   |
+| `datasetId`       | String           | MANDATORY   | The identifier of the DSP dataset under which the certificate is exposed in the Certificate Provider's catalog, enabling the Certificate Consumer to locate and negotiate the certificate via the Dataspace Protocol. |
+| `certificateType` | String           | MANDATORY   | An opaque string identifying the certificate type (for example, `ISO9001`).                                                                                                                                       |
+| `validFrom`       | String           | CONDITIONAL | The inclusive start date of the validity period, an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`). **MUST** be present when `status` is `CREATED` or `MODIFIED`; **MAY** be omitted when `status` is `WITHDRAWN`. |
+| `validUntil`      | String           | CONDITIONAL | The inclusive end date of the validity period, an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`). Same presence rules as `validFrom`.                                                                              |
+| `enclosedSiteBpns`    | Array of Strings | OPTIONAL    | The Business Partner Numbers (BPNs) of the sites or addresses the certificate applies to. If omitted, the certificate applies to the issuing legal entity as a whole.                                             |
+
+The following are non-normative examples.
+
+**Status: CREATED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+  "time": "2025-05-04T07:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "version": 1,
+    "status": "CREATED",
+    "datasetId": "dataset-ccm-cert-abc123",
+    "certificateType": "ISO9001",
+    "validFrom": "2023-01-25",
+    "validUntil": "2026-01-24",
+    "enclosedSiteBpns": [
+      "BPNS00000003AYRE",
+      "BPNA000000000001"
+    ]
+  }
+}
+```
+
+**Status: MODIFIED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e",
+  "time": "2025-08-01T07:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json",
+  "data": {
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "version": 2,
+    "status": "MODIFIED",
+    "datasetId": "dataset-ccm-cert-abc123",
+    "certificateType": "ISO9001",
+    "validFrom": "2023-01-25",
+    "validUntil": "2027-01-24",
+    "enclosedSiteBpns": [
+      "BPNS00000003AYRE",
+      "BPNA000000000001"
+    ]
+  }
+}
+```
+
+**Status: WITHDRAWN**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "c3d4e5f6-7a8b-9c0d-1e2f-3a4b5c6d7e8f",
+  "time": "2025-09-01T07:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json",
+  "data": {
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "version": 2,
+    "status": "WITHDRAWN",
+    "datasetId": "dataset-ccm-cert-abc123",
+    "certificateType": "ISO9001"
+  }
+}
+```
+
+**Batch**
+
+Multiple events **MAY** be delivered in a single request as a JSON array:
+
+```json
+[
+  {
+    "specversion": "1.0",
+    "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+    "source": "urn:bpn:BPNL0000000001AB",
+    "subject": "BPNL0000000002CD",
+    "id": "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+    "time": "2025-05-04T07:00:00Z",
+    "datacontenttype": "application/json",
+    "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json",
+    "data": {
+      "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+      "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+      "version": 1,
+      "status": "CREATED",
+      "datasetId": "dataset-ccm-cert-abc123",
+      "certificateType": "ISO9001",
+      "validFrom": "2023-01-25",
+      "validUntil": "2026-01-24"
+    }
+  },
+  {
+    "specversion": "1.0",
+    "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+    "source": "urn:bpn:BPNL0000000001AB",
+    "subject": "BPNL0000000002CD",
+    "id": "d4e5f6a7-8b9c-0d1e-2f3a-4b5c6d7e8f90",
+    "time": "2025-09-01T07:00:00Z",
+    "datacontenttype": "application/json",
+    "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json",
+    "data": {
+      "certificateId": "cert-770e8400-e29b-41d4-a716-446655449999",
+      "version": 3,
+      "status": "WITHDRAWN",
+      "datasetId": "dataset-ccm-cert-xyz789",
+      "certificateType": "ISO14001"
+    }
+  }
+]
+```
+
+#### 4.3.2 Certificate Fulfillment Notification
+
+When a Certificate Consumer exposes this Notification API, a Certificate Provider **MAY** push the Fulfillment status of
+an open consumer-initiated exchange (see [Section 4.4.1](#441-certificate-request)) to the consumer instead of requiring
+it to poll (see [Section 4.4.2](#442-certificate-request-status)). This is the push counterpart of that poll and is
+particularly useful for long-running fulfillment, for example while a certificate is `CERTIFICATION_REQUESTED`.
+
+The event is delivered to the same `POST /certificate-notifications` endpoint defined in
+[Section 4.3.1](#431-certificate-lifecycle-events) and is distinguished by its CloudEvents `type`. It is correlated to the
+exchange by the `exchangeId` carried in `data`; the `exchangeId` is the one the Certificate Provider returned when the
+exchange was opened (see [Section 4.4.1](#441-certificate-request)).
+
+This notification reports only the Fulfillment phase. It is independent of the certificate's lifecycle status: a
+`FULFILLED` notification reports that the requested exchange has been fulfilled and the certificate is available for
+retrieval, whereas a lifecycle `CREATED` event (see [Section 4.3.1](#431-certificate-lifecycle-events)) reports a
+provider-initiated exchange. A Certificate Provider **MUST NOT** use a lifecycle event to report the outcome of a
+consumer-initiated request.
+
+**Event Type**: `org.catena-x.ccm.CertificateFulfillmentStatus.v1`
+
+The `data` payload contains the following properties:
+
+| Property        | Type            | Required    | Description                                                                                                                 |
+|-----------------|-----------------|-------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`    | String          | MANDATORY   | Identifier of the `Certificate Exchange` whose Fulfillment status is reported. Distinct from the CloudEvent `id`.           |
+| `certificateId` | String          | MANDATORY   | The unique identifier of the certificate the exchange concerns.                                                             |
+| `status`        | String          | MANDATORY   | The Fulfillment status. **MUST** be one of `ACKNOWLEDGED`, `CERTIFICATION_REQUESTED`, `FULFILLED`, `DECLINED`, or `FAILED`. |
+| `errors`        | Array of Object | CONDITIONAL | A list of error details. **MUST** be present and non-empty when `status` is `DECLINED` or `FAILED`.                         |
+
+A Certificate Provider that pushes Fulfillment status **SHOULD** send at least the terminal outcomes (`FULFILLED`,
+`DECLINED`, `FAILED`); intermediate states **MAY** also be pushed. Each entry in the `errors` array contains the
+properties defined in [Section 4.4.5](#445-certificate-acceptance-events).
+
+The following are non-normative examples.
+
+**Status: FULFILLED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateFulfillmentStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "f0e1d2c3-b4a5-6789-0abc-def012345678",
+  "time": "2025-05-04T07:30:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-fulfillment-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "FULFILLED"
+  }
+}
+```
+
+**Status: DECLINED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateFulfillmentStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "a1c2e3f4-5b6d-7e8f-9a0b-1c2d3e4f5a6b",
+  "time": "2025-05-04T07:30:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-fulfillment-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "DECLINED",
+    "errors": [
+      {
+        "message": "Certificate type not offered for the requested location"
+      }
+    ]
+  }
+}
+```
+
+#### 4.3.3 Certificate Acceptance Status Query
+
+The Certificate Consumer **MUST** expose the following endpoint to allow a Certificate Provider to query the current
+acceptance status of a `Certificate Exchange` it opened.
+
+|                  |                                                     |
+|------------------|-----------------------------------------------------|
+| **HTTP Method**: | GET                                                 |
+| **URL Path**     | `GET /certificate-acceptance-status/{id}`           |
+| **Content Type** | `application/json`                                  |
+| **Response**     | `CertificateAcceptanceStatusResponse` or `HTTP 404` |
+
+The `{id}` path parameter **MUST** be the `exchangeId` assigned by the Certificate Provider when the exchange was opened
+(see [Section 2.1.1](#211-identity-and-correlation)). If the `exchangeId` is unknown to the Certificate Consumer, the
+endpoint **MUST** respond with `HTTP 404`.
+
+If the Certificate Consumer has not yet concluded processing, the endpoint **MAY** return a
+`CertificateAcceptanceStatusResponse` whose `status` is `RETRIEVED`.
+
+The response body **MUST** be a JSON object representing the current acceptance status of the exchange. The `status`
+property conveys the Acceptance-phase state, including the non-terminal value `RETRIEVED` indicating that the
+certificate has been retrieved but acceptance has not yet concluded. The `errors` follow the same rules as the
+corresponding acceptance event in [Section 4.4.5](#445-certificate-acceptance-events).
+
+| Property        | Type            | Required  | Description                                                                                                                                                              |
+|-----------------|-----------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`    | String          | MANDATORY | The identifier of the `Certificate Exchange`. Matches the `{id}` path parameter of the request.                                                                          |
+| `certificateId` | String          | MANDATORY | The unique identifier of the certificate the status applies to.                                                                                                          |
+| `status`        | String          | MANDATORY | The current acceptance status. **MUST** be one of `RETRIEVED`, `ACCEPTED`, `REJECTED`, or `ERRORED`.                                                                     |
+| `errors`        | Array of Object | OPTIONAL  | A list of error details. **MUST NOT** be present when `status` is `RETRIEVED` or `ACCEPTED`. **MUST** be present and non-empty when `status` is `REJECTED` or `ERRORED`. |
+
+Each entry in the `errors` array contains the same properties as defined in
+[Section 4.4.5](#445-certificate-acceptance-events):
+
+| Property    | Type   | Required  | Description                                                                                                                                                  |
+|-------------|--------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `message`   | String | MANDATORY | A human-readable description of the error.                                                                                                                   |
+| `specifier` | String | OPTIONAL  | An identifier scoping the error to a particular element of the certificate, such as a site BPN. If omitted, the error applies to the certificate as a whole. |
+
+The following are non-normative examples of acceptance status responses:
+
+**Status: RETRIEVED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "status": "RETRIEVED"
+}
+```
+
+**Status: ACCEPTED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "status": "ACCEPTED"
+}
+```
+
+**Status: REJECTED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "status": "REJECTED",
+  "errors": [
+    {
+      "message": "Certificate has expired"
+    },
+    {
+      "specifier": "BPNS000000000002",
+      "message": "Site BPNS000000000002 has been Rejected"
+    }
+  ]
+}
+```
+
+#### 4.3.4 OpenAPI Specification
+
+The Certificate Consumer Notification API is formally defined by the OpenAPI document
+[certificate-consumer-notification-api-combined.yaml](./certificate-consumer-notification-api-combined.yaml).
+
+#### 4.3.5 DSP Dataset Representation
+
+The Certificate Consumer **MUST** expose a dataset according to the Dataspace Protocol (DSP) specification in their
+catalog. This dataset **MUST** include the following properties:
+
+|                 |                                                                                                                                           |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| **conformsTo**: | The Dublin Core [conformsTo](#dcmi-conformsto) property. The value must be set to `https://w3id.org/catenax/certificate-notification-api` |
+
+The catalog distribution **MUST** have its `format` value set to `https://w3id.org/dps/http-pull`.
+
+> TODO: Note this section is dependent on the following issues:
+> - [DPS-99](#dps-99)
+
+The following is a non-normative example of a consumer catalog dataset:
+
+```json
+{
+  "@id": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
+  "@type": "Dataset",
+  "hasPolicy": [],
+  "conformsTo": "https://w3id.org/catenax/certificate-notification-api",
+  "distribution": [
+    {
+      "@type": "Distribution",
+      "format": "https://w3id.org/dps/http-pull",
+      "accessService": "urn:uuid:4aa2dcc8-4d2d-569e-d634-8394a8834d77"
+    }
+  ]
+}
+```
+
+### 4.4 Certificate Provider API
+
+> *This section is normative*
+
+The Certificate Provider API enables Certificate Providers to accept certificate requests, report request fulfillment
+status, serve certificate data, answer certificate queries, and receive acceptance status from Certificate Consumers.
+
+#### 4.4.1 Certificate Request
+
+The Certificate Provider **MUST** expose the following endpoint to allow a Certificate Consumer to request a
+certificate. A request opens a consumer-initiated `Certificate Exchange` (see [Section 2.1](#21-certificate-exchange)).
+
+|                  |                                                       |
+|------------------|-------------------------------------------------------|
+| **HTTP Method**: | POST                                                  |
+| **URL Path**     | `POST /certificate-requests`                          |
+| **Content Type** | `application/json`                                    |
+| **Request**      | `CertificateRequest`                                  |
+| **Response**     | `HTTP 202` with `CertificateRequestResponse` or error |
+
+The request body **MUST** be a JSON object containing the following properties:
+
+| Property          | Type             | Required  | Description                                                                                                                                |
+|-------------------|------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `certificateType` | String           | MANDATORY | An opaque string identifying the certificate type to be requested (for example, `ISO9001`).                                                |
+| `enclosedSiteBpns`    | Array of Strings | OPTIONAL  | The Business Partner Numbers (BPNs) of the sites or addresses the request applies to. If omitted, the request applies to the legal entity. |
+
+When the Certificate Provider accepts the request, it **MUST** assign an `exchangeId`, `certificateId`, and `version`
+and return them in the response, so the Certificate Consumer can correlate the exchange, poll its fulfillment status,
+and later retrieve the certificate. The response body **MUST** be a JSON object containing the following properties:
+
+| Property        | Type            | Required  | Description                                                                                                                           |
+|-----------------|-----------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`    | String          | MANDATORY | The identifier assigned to the opened `Certificate Exchange`. Used to poll status ([Section 4.4.2](#442-certificate-request-status)). |
+| `certificateId` | String          | MANDATORY | The identifier assigned to the requested certificate. Used to retrieve it via `GET /certificates/{id}`.                               |
+| `version`       | Integer         | MANDATORY | The version assigned to the requested certificate.                                                                                    |
+| `status`        | String          | MANDATORY | The fulfillment status of the request. **MUST** be one of `ACKNOWLEDGED`, `CERTIFICATION_REQUESTED`, `FULFILLED`, or `DECLINED`.      |
+| `errors`        | Array of Object | OPTIONAL  | A list of error details. **MUST** be present and non-empty when `status` is `DECLINED`.                                               |
+
+The `status` reflects the Fulfillment phase of the exchange (see [Section 2.1.3](#213-state-machine)). A Certificate
+Provider that already holds the requested certificate **MAY** return `FULFILLED` immediately. A Certificate Provider
+that will not satisfy the request **MAY** return `DECLINED` with errors, or respond with `HTTP 400` if the request is
+malformed. Each entry in the `errors` array contains the properties defined in
+[Section 4.4.5](#445-certificate-acceptance-events).
+
+The following is a non-normative example of a certificate request:
+
+```json
+{
+  "certificateType": "ISO9001",
+  "enclosedSiteBpns": [
+    "BPNS00000003AYRE"
+  ]
+}
+```
+
+The following is a non-normative example of a response (`HTTP 202`):
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "version": 1,
+  "status": "ACKNOWLEDGED"
+}
+```
+
+#### 4.4.2 Certificate Request Status
+
+The Certificate Provider **MUST** expose the following endpoint to allow a Certificate Consumer to poll the fulfillment
+status of a request previously submitted via [Section 4.4.1](#441-certificate-request).
+
+|                  |                                          |
+|------------------|------------------------------------------|
+| **HTTP Method**: | GET                                      |
+| **URL Path**     | `GET /certificate-requests/{id}`         |
+| **Content Type** | `application/json`                       |
+| **Response**     | `CertificateRequestStatus` or `HTTP 404` |
+
+The `{id}` path parameter **MUST** be the `exchangeId` returned by the Certificate Provider in the response to the
+certificate request. If the `exchangeId` is unknown to the Certificate Provider, the endpoint **MUST** respond with
+`HTTP 404`.
+
+The response body **MUST** be a JSON object containing the following properties:
+
+| Property        | Type            | Required  | Description                                                                                                                         |
+|-----------------|-----------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`    | String          | MANDATORY | The identifier of the `Certificate Exchange`. Matches the `{id}` path parameter of the request.                                     |
+| `certificateId` | String          | MANDATORY | The unique identifier of the requested certificate.                                                                                 |
+| `version`       | Integer         | MANDATORY | The version of the requested certificate.                                                                                           |
+| `status`        | String          | MANDATORY | The current fulfillment status. **MUST** be one of `ACKNOWLEDGED`, `CERTIFICATION_REQUESTED`, `FULFILLED`, `DECLINED`, or `FAILED`. |
+| `errors`        | Array of Object | OPTIONAL  | A list of error details. **MUST** be present and non-empty when `status` is `DECLINED` or `FAILED`.                                 |
+
+When the `status` is `FULFILLED`, the certificate is available and **MAY** be retrieved via
+[Section 4.4.3](#443-certificate-retrieval). This endpoint reports only the Fulfillment phase; the Certificate
+Consumer's acceptance outcome is reported separately via [Section 4.4.5](#445-certificate-acceptance-events).
+
+Polling is not the only way to learn the Fulfillment status. If the Certificate Consumer exposes the Certificate
+Consumer Notification API, a Certificate Provider **MAY** instead push these status updates to it as they occur (see
+[Section 4.3.2](#432-certificate-fulfillment-notification)), in which case the consumer need not poll. The two mechanisms
+are equivalent and carry the same `exchangeId` and `status`.
+
+The following are non-normative examples of request status responses:
+
+**Status: ACKNOWLEDGED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "version": 1,
+  "status": "ACKNOWLEDGED"
+}
+```
+
+**Status: FULFILLED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "version": 1,
+  "status": "FULFILLED"
+}
+```
+
+**Status: DECLINED**
+
+```json
+{
+  "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "version": 1,
+  "status": "DECLINED",
+  "errors": [
+    {
+      "message": "Certificate type not offered for the requested location"
+    }
+  ]
+}
+```
+
+#### 4.4.3 Certificate Retrieval
+
+The Certificate Provider **MUST** expose the following endpoint to retrieve certificate metadata.
+
+|                  |                                           |
+|------------------|-------------------------------------------|
+| **HTTP Method**: | GET                                       |
+| **URL Path**     | `GET /certificates/{id}`                  |
+| **Query**        | `version` (OPTIONAL) — defaults to latest |
+| **Content Type** | `application/json`                        |
+| **Response**     | `HTTP 200` with metadata JSON or error    |
+
+The response is a JSON object ([RFC8259](#rfc8259)) describing the certificate. The certificate is metadata only; the
+binary documents are **not** included. Each associated document is listed by reference in the `documents` array and
+retrieved independently via [Section 4.4.4](#444-document-retrieval).
+
+If an error occurs, the Certificate Provider **MUST** set the `Content-Type` to `application/json` and return an error
+body encoded as `application/json` ([RFC8259](#rfc8259)).
+
+By default, the endpoint returns the latest `version`. A consumer **MAY** request a specific version with the `version`
+query parameter (for example, `GET /certificates/{id}?version=2`) — for instance, to retrieve the exact version a
+`Certificate Exchange` concerns. The Certificate Provider **MUST** be able to return any version that is still
+referenced by a non-terminal `Certificate Exchange`; whether other superseded versions remain retrievable is at the
+provider's discretion.
+
+Each version references a set of documents through the `documents` array. Document identity is independent of the
+certificate version: a `documentId` is stable and its content is immutable. A document that does not change across
+versions is therefore referenced by the same `documentId` in each version that includes it.
+
+The metadata is a JSON object containing the following properties:
+
+| Property                 | Type             | Required  | Description                                                                                                                                                           |
+|--------------------------|------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `certificateId`          | String           | MANDATORY | The unique identifier of the certificate. Matches the `{id}` path parameter of the request.                                                                           |
+| `version`                | Integer          | MANDATORY | The version returned — the version requested via the `version` query parameter, or the latest version if none was specified.                                          |
+| `certificateType`        | String           | MANDATORY | An opaque string identifying the certificate type (for example, `ISO9001`). See [Section 5.4](#54-certificate-types).                                                 |
+| `certificateTypeVersion` | String           | OPTIONAL  | The version of the certificate type itself (for example, `2015` for ISO 9001:2015). Distinct from the certificate's `version`.                                        |
+| `certifiedBpn`           | String           | MANDATORY | The BPNL of the certified legal entity on which the certificate is issued.                                                                                            |
+| `registrationNumber`     | String           | MANDATORY | The certificate's registration number at the issuing body.                                                                                                           |
+| `validFrom`              | String           | MANDATORY | The inclusive start date of the certificate validity period, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`).                                           |
+| `validUntil`             | String           | MANDATORY | The inclusive end date of the certificate validity period, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`).                                             |
+| `trustLevel`             | String           | MANDATORY | The trust level of the certificate. **MUST** be one of `none`, `low`, `medium`, `high`, or `trusted` (see [Section 5.5](#55-certificate-metadata-attributes)).        |
+| `areaOfApplication`      | String           | OPTIONAL  | Free-text detail of the areas or application types the certificate is valid for overall. Individual locations **MAY** narrow this via `Location.areaOfApplication`.   |
+| `enclosedSites`              | Array of Objects | OPTIONAL  | The sites or addresses the certificate applies to, each an `EnclosedSite` object (see below). If omitted or empty, the certificate applies to the issuing legal entity as a whole. |
+| `issuer`                 | Object           | OPTIONAL  | The authority that issued the certificate, a `CertificateIssuer` object (see below).                                                                                  |
+| `validator`              | Object           | OPTIONAL  | The party that can validate the certificate information, a `CertificateValidator` object (see below).                                                                 || `documents`              | Array of Objects | OPTIONAL  | The documents associated with this certificate version, each a `CertificateDocument` object (see below). If omitted or empty, the version has no associated documents. |
+
+Each `EnclosedSite` object contains the following properties:
+
+| Property            | Type   | Required  | Description                                                                                                          |
+|---------------------|--------|-----------|--------------------------------------------------------------------------------------------------------------------|
+| `bpn`       | String | MANDATORY | The Business Partner Number of the site (BPNS) or address (BPNA) the certificate covers.                            |
+| `areaOfApplication` | String | OPTIONAL  | Free-text detail of the areas or application types the certificate is valid for at this specific location.          |
+
+Each `CertificateIssuer` object contains the following properties:
+
+| Property     | Type   | Required  | Description                                                                |
+|--------------|--------|-----------|---------------------------------------------------------------------------|
+| `issuerName` | String | MANDATORY | The name of the issuing authority (for example, `TÜV Süd`).               |
+| `issuerBpn`  | String | OPTIONAL  | The BPNL of the issuing authority, if it is a Catena-X business partner.   |
+
+Each `CertificateValidator` object contains the following properties:
+
+| Property        | Type   | Required  | Description                                                                                                              |
+|-----------------|--------|-----------|-------------------------------------------------------------------------------------------------------------------------|
+| `validatorName` | String | MANDATORY | The name of the validator.                                                                                              |
+| `validatorBpn`  | String | OPTIONAL  | The BPNL of the validator. **MAY** be used as a free-text identifier where a BPNL is not available.                     |
+
+Each `CertificateDocument` object contains the following properties:
+
+| Property     | Type   | Required  | Description                                                                                                                                                  |
+|--------------|--------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `documentId` | String | MANDATORY | The opaque, version-independent identifier of the document, used to retrieve it via `GET /documents/{id}` (see [Section 4.4.4](#444-document-retrieval)).     |
+| `language`   | String | OPTIONAL  | The language of the document as an [ISO 639-1](#iso6391) two-letter code (for example, `en` or `de`). Distinguishes documents that differ only by language.   |
+| `mediaType`  | String | MANDATORY | The IANA media type of the document binary (for example, `application/pdf` or `image/png`).                                                                  |
+
+The following is a non-normative example of a response:
+
+```json
+{
+  "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+  "version": 1,
+  "certificateType": "ISO9001",
+  "certificateTypeVersion": "2015",
+  "certifiedBpn": "BPNL0000000002CD",
+  "registrationNumber": "12 100 4711",
+  "validFrom": "2023-01-25",
+  "validUntil": "2026-01-24",
+  "trustLevel": "high",
+  "areaOfApplication": "Production and assembly of powertrain components",
+  "enclosedSites": [
+    {
+      "bpn": "BPNS00000003AYRE",
+      "areaOfApplication": "Welding and surface treatment"
+    },
+    {
+      "bpn": "BPNA000000000001"
+    }
+  ],
+  "issuer": {
+    "issuerName": "TÜV Süd",
+    "issuerBpn": "BPNL0000000003EF"
+  },
+  "validator": {
+    "validatorName": "TÜV Süd",
+    "validatorBpn": "BPNL0000000003EF"
+  },  "documents": [
+    {
+      "documentId": "doc-3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "language": "en",
+      "mediaType": "application/pdf"
+    }
+  ]
+}
+```
+
+#### 4.4.4 Document Retrieval
+
+The Certificate Provider **MUST** expose the following endpoint to retrieve a certificate document by its identifier.
+
+|                  |                                              |
+|------------------|----------------------------------------------|
+| **HTTP Method**: | GET                                          |
+| **URL Path**     | `GET /documents/{id}`                        |
+| **Content Type** | The document's `mediaType`                   |
+| **Response**     | `HTTP 200` with the document binary or error |
+
+A document is identified by an opaque `documentId` that is independent of any certificate version (see
+[Section 4.4.3](#443-certificate-retrieval)). Because a document's identity and content are stable, the same document
+**MAY** be referenced by multiple certificate versions, and the endpoint therefore requires no `version` parameter.
+
+The response body is the document binary, served directly with the `Content-Type` set to the document's `mediaType`
+(for example, `application/pdf`) as advertised in the certificate metadata
+([Section 4.4.3](#443-certificate-retrieval)).
+
+If an error occurs, the Certificate Provider **MUST** set the `Content-Type` to `application/json` and return an error
+body encoded as `application/json` ([RFC8259](#rfc8259)).
+
+The following is a non-normative example of a response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/pdf
+
+[binary document data]
+```
+
+#### 4.4.5 Certificate Acceptance Events
+
+The Certificate Provider **MUST** expose the following endpoint to receive certificate acceptance status from the
+Certificate Consumer. The status is delivered as a `CertificateAcceptanceStatus` CloudEvent.
+
+|                  |                                                       |
+|------------------|-------------------------------------------------------|
+| **HTTP Method**: | POST                                                  |
+| **URL Path**     | `POST /certificate-acceptance-notifications`          |
+| **Content Type** | `application/cloudevents+json`                        |
+| **Request**      | `CertificateAcceptanceStatus` (single event or batch) |
+| **Response**     | `HTTP 204` with empty body or error                   |
+
+The endpoint accepts a single CloudEvent ([CloudEvents](#cloudevents)) or a batch (a JSON array) as defined in
+[CX-0000](#cx-0000), whose HTTP binding follows [CloudEvents-HTTP](#cloudevents-http).
+
+**Event Type**: `org.catena-x.ccm.CertificateAcceptanceStatus.v1`
+
+The Certificate Provider **MUST** dispatch on the `data.status` value, which is a state of the Acceptance phase (see
+[Section 2.1.3](#213-state-machine)). The event is correlated to its `Certificate Exchange` by the `exchangeId` carried
+in `data` (see [Section 2.1.1](#211-identity-and-correlation)).
+
+Acceptance status **MUST** reference an existing `Certificate Exchange`. Acceptance is the Consumer-owned phase of an
+exchange, so it can only be reported when an exchange is present — one opened by a consumer request
+([Section 4.4.1](#441-certificate-request)) or by a provider notification
+([Section 4.3.1](#431-certificate-lifecycle-events)). Merely retrieving a certificate (for example, after
+a [query](#446-certificate-query)) does **not** establish an exchange and therefore does not permit acceptance feedback.
+If the `exchangeId` is unknown to the Certificate Provider, it **MUST** reject the event with `HTTP 404`.
+
+Reporting `RETRIEVED` is **OPTIONAL** (see [Section 2.1.3](#213-state-machine)). It is a non-terminal delivery
+acknowledgment; a Certificate Consumer **MAY** report it after fetching the certificate, or **MAY** proceed directly to
+a terminal acceptance status (`ACCEPTED`, `REJECTED`, or `ERRORED`) without first reporting `RETRIEVED`. A Certificate
+Provider **MUST NOT** require a prior `RETRIEVED` event as a precondition for accepting a terminal acceptance status.
+
+The `data` payload derives from the common certificate-status base payload and constrains `status` to the acceptance
+values below. It contains the following properties:
+
+| Property        | Type            | Required    | Description                                                                                                                                                              |
+|-----------------|-----------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `exchangeId`    | String          | MANDATORY   | Identifier of the `Certificate Exchange` this event reports on. Distinct from the CloudEvent `id`.                                                                       |
+| `certificateId` | String          | MANDATORY   | The unique identifier of the certificate the status applies to.                                                                                                          |
+| `status`        | String          | MANDATORY   | The acceptance status of the certificate. **MUST** be one of `RETRIEVED`, `ACCEPTED`, `REJECTED`, or `ERRORED`.                                                          |
+| `errors`        | Array of Object | CONDITIONAL | A list of error details. **MUST NOT** be present when `status` is `RETRIEVED` or `ACCEPTED`. **MUST** be present and non-empty when `status` is `REJECTED` or `ERRORED`. |
+
+Each entry in the `errors` array contains the following properties:
+
+| Property    | Type   | Required  | Description                                                                                                                                                  |
+|-------------|--------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `message`   | String | MANDATORY | A human-readable description of the error.                                                                                                                   |
+| `specifier` | String | OPTIONAL  | An identifier scoping the error to a particular element of the certificate, such as a site BPN. If omitted, the error applies to the certificate as a whole. |
+
+The following are non-normative examples.
+
+**Status: RETRIEVED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateAcceptanceStatus.v1",
+  "source": "urn:bpn:BPNL0000000002CD",
+  "subject": "BPNL0000000001AB",
+  "id": "e9f8d7c6-b5a4-9382-7160-5a4b3c2d1e0f",
+  "time": "2025-05-04T08:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "RETRIEVED"
+  }
+}
+```
+
+**Status: ACCEPTED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateAcceptanceStatus.v1",
+  "source": "urn:bpn:BPNL0000000002CD",
+  "subject": "BPNL0000000001AB",
+  "id": "a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d",
+  "time": "2025-05-04T09:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "ACCEPTED"
+  }
+}
+```
+
+**Status: REJECTED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateAcceptanceStatus.v1",
+  "source": "urn:bpn:BPNL0000000002CD",
+  "subject": "BPNL0000000001AB",
+  "id": "f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c",
+  "time": "2025-05-04T09:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "REJECTED",
+    "errors": [
+      {
+        "message": "Certificate has expired"
+      },
+      {
+        "message": "Unexpected data format"
+      },
+      {
+        "specifier": "BPNS000000000002",
+        "message": "Site BPNS000000000002 has been Rejected"
+      }
+    ]
+  }
+}
+```
+
+**Status: ERRORED**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateAcceptanceStatus.v1",
+  "source": "urn:bpn:BPNL0000000002CD",
+  "subject": "BPNL0000000001AB",
+  "id": "c8d7e6f5-a4b3-2109-8765-432109fedcba",
+  "time": "2025-05-04T08:30:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "ERRORED",
+    "errors": [
+      {
+        "message": "Certificate document is malformed and cannot be validated"
+      }
+    ]
+  }
+}
+```
+
+#### 4.4.6 Certificate Query
+
+The Certificate Provider **MUST** expose the following endpoint to query certificates.
+
+|                  |                            |
+|------------------|----------------------------|
+| **HTTP Method**: | POST                       |
+| **URL Path**     | `POST /certificates/search` |
+| **Content Type** | `application/json`         |
+| **Request**      | `CertificateQuery`         |
+| **Response**     | `CertificateQueryResponse` |
+
+The request body **MUST** be a JSON object containing the query criteria. The `limit` property **MAY** be included to
+indicate the maximum number of results to return per page. If omitted, the Certificate Provider **MAY** apply a default
+limit.
+
+The `CertificateQuery` object contains the following properties. All criteria are **OPTIONAL**; a query with no criteria
+returns all certificates accessible to the Certificate Consumer. Criteria of different kinds are combined with **AND**
+(a certificate is returned only if it satisfies every supplied criterion). Within a single BPN list, the match is
+**any-of** (a certificate matches if it covers any one of the listed BPNs).
+
+| Property           | Type             | Required | Description                                                                                                                                                                                              |
+|--------------------|------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `certificateType`  | String           | OPTIONAL | An opaque string identifying the certificate type to be matched (for example, `ISO9001`). See [Section 5.4](#54-certificate-types).                                                                       |
+| `legalEntityBpns`  | Array of Strings | OPTIONAL | Filter to certificates issued for these legal entities (matched against `certifiedBpn`). Each value is a BPNL.                                                                                            |
+| `siteBpns`         | Array of Strings | OPTIONAL | Filter to certificates covering these sites (matched against the `enclosedSites`). Each value is a BPNS.                                                                                                  |
+| `addressBpns`      | Array of Strings | OPTIONAL | Filter to certificates covering these addresses (matched against the `enclosedSites`). Each value is a BPNA.                                                                                              |
+| `from`             | String           | OPTIONAL | The inclusive lower bound of the certificate validity range, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`). Only certificates whose `validFrom` is on or after this date are returned.    |
+| `to`               | String           | OPTIONAL | The inclusive upper bound of the certificate validity range, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`). Only certificates whose `validUntil` is on or before this date are returned.  |
+| `limit`            | Integer          | OPTIONAL | The maximum number of results to return in a single page. If omitted, the Certificate Provider **MAY** apply a default limit.                                                                            |
+
+The following is a non-normative example of a certificate query:
+
+```json
+{
+  "certificateType": "ISO9001",
+  "legalEntityBpns": [
+    "BPNL0000000002CD"
+  ],
+  "siteBpns": [
+    "BPNS00000003AYRE"
+  ],
+  "from": "2023-01-25",
+  "to": "2026-01-24",
+  "limit": 50
+}
+```
+
+The response body **MUST** be a JSON array of `CertificateQueryResponse` objects containing match results. Each object
+contains the following properties:
+
+| Property          | Type             | Required  | Description                                                                                                                                                           |
+|-------------------|------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `certificateId`          | String           | MANDATORY | The unique identifier of the certificate, used to retrieve the certificate via `GET /certificates/{id}`.                                                              |
+| `version`                | Integer          | MANDATORY | The latest version of the certificate.                                                                                                                                |
+| `datasetId`              | String           | MANDATORY | The identifier of the DSP dataset under which the certificate is exposed in the Certificate Provider's catalog, enabling the Certificate Consumer to locate and negotiate the certificate via the Dataspace Protocol. |
+| `certificateType`        | String           | MANDATORY | An opaque string identifying the certificate type (for example, `ISO9001`). See [Section 5.4](#54-certificate-types).                                                 |
+| `certificateTypeVersion` | String           | OPTIONAL  | The version of the certificate type itself (for example, `2015` for ISO 9001:2015). Distinct from the certificate's `version`.                                        |
+| `certifiedBpn`           | String           | MANDATORY | The BPNL of the certified legal entity on which the certificate is issued.                                                                                            |
+| `registrationNumber`     | String           | MANDATORY | The certificate's registration number at the issuing body.                                                                                                           |
+| `validFrom`              | String           | MANDATORY | The inclusive start date of the certificate validity period, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`).                                           |
+| `validUntil`             | String           | MANDATORY | The inclusive end date of the certificate validity period, formatted as an [ISO 8601](#iso8601) full-date (`YYYY-MM-DD`).                                             |
+| `trustLevel`             | String           | MANDATORY | The trust level of the certificate. **MUST** be one of `none`, `low`, `medium`, `high`, or `trusted` (see [Section 5.5](#55-certificate-metadata-attributes)).        |
+| `areaOfApplication`      | String           | OPTIONAL  | Free-text detail of the areas or application types the certificate is valid for.                                                                                      |
+| `enclosedSiteBpns`           | Array of Strings | OPTIONAL  | The Business Partner Numbers (BPNs) of the sites or addresses the certificate applies to. If omitted, the certificate applies to the issuing legal entity as a whole. |
+| `issuer`                 | Object           | OPTIONAL  | The authority that issued the certificate, a `CertificateIssuer` object as defined in [Section 4.4.3](#443-certificate-retrieval).                                    |
+| `validator`              | Object           | OPTIONAL  | The party that can validate the certificate, a `CertificateValidator` object as defined in [Section 4.4.3](#443-certificate-retrieval).                               || `documents`              | Array of Objects | OPTIONAL  | The documents associated with the returned certificate version, each a `CertificateDocument` object as defined in [Section 4.4.3](#443-certificate-retrieval). Retrieved via `GET /documents/{id}`. |
+
+The following is a non-normative example of a certificate query response containing an array of
+`CertificateQueryResponse` objects:
+
+```json
+[
+  {
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "version": 1,
+    "datasetId": "dataset-ccm-cert-abc123",
+    "certificateType": "ISO9001",
+    "certificateTypeVersion": "2015",
+    "certifiedBpn": "BPNL0000000002CD",
+    "registrationNumber": "12 100 4711",
+    "validFrom": "2023-01-25",
+    "validUntil": "2026-01-24",
+    "trustLevel": "high",
+    "areaOfApplication": "Production and assembly of powertrain components",
+    "enclosedSiteBpns": [
+      "BPNS00000003AYRE",
+      "BPNA000000000001"
+    ],
+    "issuer": {
+      "issuerName": "TÜV Süd",
+      "issuerBpn": "BPNL0000000003EF"
+    },
+    "validator": {
+      "validatorName": "TÜV Süd",
+      "validatorBpn": "BPNL0000000003EF"
+    },
+    "documents": [
+      {
+        "documentId": "doc-3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "language": "en",
+        "mediaType": "application/pdf"
+      }
+    ]
+  }
+]
+```
+
+##### 4.4.6.1 Pagination
+
+Implementations **MAY** paginate the results of a query. When results are paginated, pagination data **MUST** be
+conveyed using Web Linking as defined in [RFC8288](#rfc8288) via the HTTP `Link` response header. Only the `next`
+and `prev` link relation types **MUST** be supported; implementations **MAY** include additional relation types such as
+`first` and `last`.
+
+Each value in the `Link` header **MUST** be enclosed in angle brackets and **MUST** include a `rel` parameter
+identifying the link relation type. When more than one link is present, values **MUST** be comma-separated as defined
+in [RFC8288, Section 3](#rfc8288). The target URL **MUST** refer to the
+`POST /certificates/search` endpoint of the Certificate Provider. The content and structure of the URL (including any
+query parameters or opaque page tokens used to encode pagination state) are not defined by this specification and
+clients **MUST** treat them as opaque.
+
+To retrieve the next or previous page, a client **MUST** issue a `POST` request to the URL provided in the corresponding
+`Link` header value, using the same request body as the original query. The `Link` header **MUST NOT** be included in
+responses that are not paginated, and a `next` or `prev` link **MUST** be omitted when no further results are available
+in that direction.
+
+The following is a non-normative example of a paginated response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Link: <https://provider.example.com/certificates/search?cursor=eyJvZmZzZXQiOjUwfQ>; rel="next",
+      <https://provider.example.com/certificates/search?cursor=eyJvZmZzZXQiOjB9>; rel="prev"
+
+[
+  {
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "version": 1,
+    "datasetId": "dataset-ccm-cert-abc123",
+    "certificateType": "ISO9001",
+    "validFrom": "2023-01-25",
+    "validUntil": "2026-01-24",
+    "enclosedSiteBpns": [
+      "BPNS00000003AYRE",
+      "BPNA000000000001"
+    ]
+  }
+]
+```
+
+#### 4.4.7 OpenAPI Specification
+
+The Certificate Provider API is formally defined by the OpenAPI document
+[certificate-provider-api-combined.yaml](./certificate-provider-api-combined.yaml).
+
+#### 4.4.8 DSP Dataset Representation
+
+The Certificate Provider **MUST** expose a dataset according to the Dataspace Protocol (DSP) specification in their
+catalog. This dataset **MUST** include the following properties:
+
+|                 |                                                                                                                              |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------|
+| **conformsTo**: | The Dublin Core [conformsTo](#dcmi-conformsto) property. The value must be set to `https://w3id.org/catenax/certificate-api` |
+
+The catalog distribution **MUST** have its `format` value set to `https://w3id.org/dps/http-pull`.
+
+> TODO: Note this section is dependent on the following issues:
+> - [DPS-98](#dps-98)
+> - [DPS-99](#dps-99)
+
+The following is a non-normative example of a provider catalog dataset:
+
+```json
+{
+  "@id": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
+  "@type": "Dataset",
+  "hasPolicy": [],
+  "conformsTo": "https://w3id.org/catenax/certificate-api",
+  "distribution": [
+    {
+      "@type": "Distribution",
+      "format": "https://w3id.org/dps/http-pull",
+      "accessService": "urn:uuid:4aa2dcc8-4d2d-569e-d634-8394a8834d77"
+    }
+  ]
+}
+```                              
+
+### 4.5 Policy Constraints and Usage Policy
+
+#### 4.5.1 Policy Constraints for Data Exchange
+
+In alignment with the commitment to data sovereignty, a framework governing the use of data within the Catena-X use
+cases has been defined. As part of this framework, conventions for access policies, usage policies, and the constraints
+they contain are specified in [CX-0152](#cx-0152) Policy Constraints for Data Exchange. [CX-0152](#cx-0152) **MUST** be
+followed when providing services or applications for sharing or consuming data, and when sharing or consuming data, in
+the Catena-X ecosystem. Which conventions are relevant for which roles named in
+[FOR WHOM IS THE STANDARD DESIGNED](#for-whom-is-the-standard-designed) is specified in [CX-0152](#cx-0152) as well.
+
+#### 4.5.2 Usage Policy
+
+All dataspace offers of a participant — both the APIs defined in this standard and the certificate datasets — **MUST**
+carry a usage policy following the requirements referenced in [Section 4.5.1](#451-policy-constraints-for-data-exchange).
+This use case introduces the following usage purpose:
+
+- **`cx.ccm.base:1`** — *the legal meaning is defined in [CX-0152](#cx-0152) (see the Catena-X standard library).*
+
+Additional, more general usage policies **MAY** be included, but every usage policy **MUST** contain the usage purpose
+above, as shown below.
+
+*Minimal example of a usage policy without a contract reference:*
+
+```json
+{
+  "@context": [
+    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/catenax/2025/9/policy/context.jsonld"
+  ],
+  "@type": "Set",
+  "@id": "CCMAPI-usage-policy-without-contract-reference",
+  "permission": [
+    {
+      "action": "use",
+      "constraint": {
+        "and": [
+          {
+            "leftOperand": "FrameworkAgreement",
+            "operator": "eq",
+            "rightOperand": "DataExchangeGovernance:1.0"
+          },
+          {
+            "leftOperand": "UsagePurpose",
+            "operator": "isAnyOf",
+            "rightOperand": "cx.ccm.base:1"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+The constraint `{ "leftOperand": "ContractReference" }` **MUST** be included only if such a bilateral framework contract
+exists:
+
+```json
+{
+  "leftOperand": "ContractReference",
+  "operator": "isAllOf",
+  "rightOperand": "x12345"
+}
+```
+
+## 5 Terminology
+
+> *This section is non-normative.*
+
+This section summarizes the terms used throughout this standard. The authoritative definitions are given in the
+conceptual model ([Section 2](#2-model)); the entries below are a quick reference and point to that section.
+
+#### 5.1 Certificate Provider and Certificate Consumer
+
+**Certificate Provider**: An entity that offers company certificates to other Catena-X participants. The Certificate
+Provider exposes the [Certificate Provider API](#44-certificate-provider-api), manages certificates in its backend,
+responds to certificate requests, and may notify Certificate Consumers of lifecycle changes.
+
+**Certificate Consumer**: An entity that requests, retrieves, and validates company certificates from Certificate
+Providers. The Certificate Consumer may request certificates, report acceptance status, and — if it exposes the
+[Certificate Consumer Notification API](#43-certificate-consumer-notification-api) — receive notifications.
+
+#### 5.2 Core Concepts
+
+| Term | Definition |
+|------|------------|
+| `Certificate Exchange` | A single, correlatable interaction delivering one certificate from a Certificate Provider to a Certificate Consumer, with its own identity and lifecycle. See [Section 2.1](#21-certificate-exchange). |
+| `Certificate Lifecycle` | The independent lifecycle of a certificate as an artifact — creation, modification, and withdrawal. See [Section 2.2](#22-certificate-lifecycle). |
+| `exchangeId` | The identifier assigned to a `Certificate Exchange` when it is opened; the correlation handle for the whole interaction. See [Section 2.1.1](#211-identity-and-correlation). |
+| `certificateId` | The stable identifier of a certificate across its lifetime. See [Section 2.2.1](#221-identity-and-versioning). |
+| `version` | The integer version of a certificate; incremented on each `MODIFIED`. A certificate is identified by the (`certificateId`, `version`) pair. See [Section 2.2.1](#221-identity-and-versioning). |
+| `certificateType` | An opaque string identifying the type of certificate (for example, `ISO9001`). |
+| `enclosedSites` / `enclosedSiteBpns` | The sites/addresses a certificate applies to; a fixed property of the certificate. The full certificate record uses structured `enclosedSites` (per-location area of application); query results and lifecycle events use bare `enclosedSiteBpns`. See [Section 2.2.1](#221-identity-and-versioning). |
+| `documentId` | The opaque, version-independent identifier of a certificate document, retrieved via `GET /documents/{id}`. See [Section 4.4.4](#444-document-retrieval). |
+| `mediaType` | The IANA media type of a document binary (for example, `application/pdf`). |
+
+#### 5.3 Status Vocabularies
+
+The Fulfillment and Acceptance phases of a `Certificate Exchange` and the publication states of a `Certificate Lifecycle`
+use the disjoint status vocabularies defined in [Section 2.1.3](#213-state-machine) and
+[Section 2.2.2](#222-state-machine) respectively.
+
+#### 5.4 Certificate Types
+
+The `certificateType` is an opaque string identifying the type of certificate a business partner is certified for (see
+[Section 5.2](#52-core-concepts)). The model is generic and not limited to a fixed list. The following types are
+commonly used:
+
+- **IATF 16949** (International Automotive Task Force) — quality management system requirements for the automotive industry.
+- **ISO 14001** — environmental management system requirements.
+- **ISO 9001** — quality management system requirements.
+- **ISO 45001 / OHSAS 18001** — occupational health and safety management systems.
+- **ISO/IEC 27001** — information security management system.
+- **ISO 50001** — energy management system.
+- **ISO/IEC 17025** — testing and calibration laboratory competence.
+- **ISO 20000** — IT service management system.
+- **ISO 22301** — business continuity management system.
+- **AEO / CTPAT / Security Declaration** — customs and supply-chain security compliance.
+- **VDA 6.4** — automotive quality management with a focus on process auditing.
+
+To maximize interoperability, producers and consumers **SHOULD** exchange `certificateType` values using a normalized
+code derived by the following rules:
+
+1. Only Latin letters and digits are used.
+2. All letters are lowercase.
+3. No whitespace, underscores, or other special characters are used.
+
+Applying these rules to the list above yields:
+
+| Name          | Code        |
+|---------------|-------------|
+| IATF 16949    | iatf16949   |
+| ISO 14001     | iso14001    |
+| ISO 9001      | iso9001     |
+| ISO 45001     | iso45001    |
+| OHSAS 18001   | ohsas18001  |
+| ISO/IEC 27001 | isoiec27001 |
+| ISO 50001     | iso50001    |
+| ISO/IEC 17025 | isoiec17025 |
+| ISO 20000     | iso20000    |
+| ISO 22301     | iso22301    |
+| AEO           | aeo         |
+| CTPAT         | ctpat       |
+| VDA6.4        | vda64       |
+
+#### 5.5 Certificate Metadata Attributes
+
+The certificate metadata returned by [Section 4.4.3](#443-certificate-retrieval) carries the following descriptive
+attributes. All BPN values are Business Partner Numbers as defined by [CX-0010](#cx-0010).
+
+| Attribute              | Meaning                                                                                                                                                                                                                                              |
+|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `certifiedBpn`         | The BPNL of the certified legal entity — the business partner the certificate is issued on.                                                                                                                                                          |
+| `registrationNumber`   | The unique identifier of the certificate at the certification authority / issuing body.                                                                                                                                                            |
+| `certificateTypeVersion` | The version of the certificate *type* (e.g. the standard edition such as `2015` for ISO 9001:2015). Independent of the certificate artifact's `version`.                                                                                          |
+| `areaOfApplication`    | Additional detail of the areas or application types for which the certificate is valid.                                                                                                                                                            |
+| `issuer`               | The authority that issued the certificate (for example, a certification body such as TÜV Süd). `issuerBpn` is the BPNL where the issuer is a Catena-X partner.                                                                                       |
+| `validator`            | The party that can validate the certificate information — ideally the issuing authority, but other validators (e.g. validation-service providers) are permitted. Related to `trustLevel`. `validatorBpn` defaults to a BPNL but **MAY** be free text. || `trustLevel`           | The degree to which the certificate has been validated. One of: `none` (uploaded, no check), `low` (manual human check), `medium` (trusted issuer plus manual check), `high` (automated cross-check against a database, e.g. TÜV/IATF), `trusted` (provided directly by the issuer). |
+
+## 6 References
+
+### 6.1 Normative References
+
+<a id="cx-0000"></a>
+**[CX-0000]** Catena-X, "CloudEventsFoundation",
+[CX-0000-CloudEventsFoundation.md](./CX-0000-CloudEventsFoundation-combined.md).
+
+<a id="cx-0010"></a>
+**[CX-0010]** Catena-X, "Business Partner Number",
+<https://catenax-ev.github.io/docs/standards/CX-0010-BusinessPartnerNumber>.
+
+<a id="cx-0151"></a>
+**[CX-0151]** Catena-X, "Industry Core: Part Type and Part Instance".
+
+<a id="cx-0152"></a>
+**[CX-0152]** Catena-X, "Policy Constraints for Data Exchange",
+<https://catenax-ev.github.io/docs/standards/CX-0152-PolicyConstrainsForDataExchange>.
+
+<a id="cloudevents"></a>
+**[CloudEvents]** Cloud Native Computing Foundation, "CloudEvents 1.0.2 — Core Specification",
+<https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md>.
+
+<a id="cloudevents-http"></a>
+**[CloudEvents-HTTP]** Cloud Native Computing Foundation, "HTTP Protocol Binding for CloudEvents 1.0.2",
+<https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/bindings/http-protocol-binding.md>.
+
+<a id="dcmi-conformsto"></a>
+**[DCMI-conformsTo]** Dublin Core Metadata Initiative, "DCMI Metadata Terms — conformsTo",
+<https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/conformsTo/>.
+
+<a id="dsp"></a>
+**[DSP]** Eclipse Dataspace Working Group, "Dataspace Protocol 2025-1",
+<https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1/>.
+
+<a id="iso6391"></a>
+**[ISO639-1]** International Organization for Standardization, "ISO 639-1:2002, Codes for the representation of names of
+languages — Part 1: Alpha-2 code", <https://www.iso.org/standard/22109.html>.
+
+<a id="iso8601"></a>
+**[ISO8601]** International Organization for Standardization, "ISO 8601-1:2019, Date and time — Representations for
+information interchange — Part 1: Basic rules", <https://www.iso.org/standard/70907.html>.
+
+<a id="rfc2119"></a>
+**[RFC2119]** Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997,
+<https://www.rfc-editor.org/rfc/rfc2119>.
+
+<a id="rfc8174"></a>
+**[RFC8174]** Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, May 2017,
+<https://www.rfc-editor.org/rfc/rfc8174>.
+
+<a id="rfc8259"></a>
+**[RFC8259]** Bray, T., Ed., "The JavaScript Object Notation (JSON) Data Interchange Format", STD 90, RFC 8259, December
+2017, <https://www.rfc-editor.org/rfc/rfc8259>.
+
+<a id="rfc8288"></a>
+**[RFC8288]** Nottingham, M., "Web Linking", RFC 8288, October 2017, <https://www.rfc-editor.org/rfc/rfc8288>.
+
+### 6.2 Non-Normative References
+
+<a id="dsp-catalog"></a>
+**[DSP-Catalog]** Eclipse Dataspace Working Group, "Dataspace Protocol 2025-1 — Catalog Protocol",
+<https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1/#catalog-protocol>.
+
+<a id="dps-98"></a>
+**[DPS-98]** Eclipse Data Plane Signaling, "Issue #98",
+<https://github.com/eclipse-dataplane-signaling/dataplane-signaling/issues/98>.
+
+<a id="dps-99"></a>
+**[DPS-99]** Eclipse Data Plane Signaling, "Issue #99",
+<https://github.com/eclipse-dataplane-signaling/dataplane-signaling/issues/99>.
+
+## ANNEXES
+
+### FIGURES
+
+> *This section is non-normative.*
+
+not applicable
+
+### TABLES
+
+> *This section is non-normative.*
+
+not applicable
+
+## Legal
+
+Copyright © 2026 Catena-X Automotive Network e.V. All rights reserved. For more information, please see [Catena-X Copyright Notice](https://catenax-ev.github.io/copyright).

--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement-merge-notes.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement-merge-notes.md
@@ -1,0 +1,240 @@
+# CX-0135 — Merge Notes (CloudEvents proposal × PR #318)
+
+> *This document records how the **combined** CX-0135 documents
+> (`CX-0135-CompanyCertificateManagement-combined.md` and its `-combined` OpenAPI specs) were produced by
+> merging the CloudEvents-based proposal (the "jim" documents) with the harmonized push/pull proposal
+> ([catenax-eV/catenax-ev.github.io#318](https://github.com/catenax-eV/catenax-ev.github.io/pull/318), the
+> "original"). It explains every element of the original that was **left out** of the combined documents.
+
+## 1 Merge methodology
+
+The governing rules were:
+
+- **CloudEvents + JSON Schema is decisive.** The data model is expressed as inline JSON Schema in the OpenAPI specs and
+  CloudEvents payloads. SAMM is not used.
+- **EDC is never referenced.** EDC is an implementation and is excluded; reference only to the Dataspace Protocol (DSP).
+- **Data-plane requirements come from jim**. The specification should not reference EDC and the EDC data plane has been
+  deprecated.
+- **Normative language follows RFC 2119 keyword style.**
+
+## 2 Incorporated
+
+The following were folded into the combined documents (sourced from the original or adapted to jim's model):
+
+| Element                      | Where                            | Notes                                                                                                                                                                                                      |
+|------------------------------|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Rich certificate metadata    | §4.4.3 / §4.4.6 / OpenAPI        | `certifiedBpn`, `registrationNumber`, `issuer`, `validator`, `trustLevel` (`none/low/medium/high/trusted`), `areaOfApplication`, `certificateTypeVersion` (the original's `uploader` is excluded — see §3) |
+| Document `language`          | §4.4.3, `CertificateDocument`    | ISO 639-1 two-letter code; distinguishes same-document-different-language                                                                                                                                  |
+| Structured covered locations | §4.4.3, `EnclosedSite`           | `enclosedSites` (objects `{ bpn, areaOfApplication }`) on the full record; flat `enclosedSiteBpns` (strings) on query results, lifecycle events, and requests                                              |
+| BPN-based search filters     | §4.4.6, `CertificateQuery`       | `legalEntityBpns` / `siteBpns` / `addressBpns`; `certificateType` made optional; AND across kinds, any-of within a list                                                                                    |
+| Policy & usage policy        | §4.5                             | CX-0152 reference; `cx.ccm.base:1` usage purpose; ODRL example. "EDC" sanitized to "dataspace offers"                                                                                                      |
+| Certificate-type catalog     | §5.4                             | Type list + normalization rules + name→code table; `certificateType` remains an opaque string                                                                                                              |
+| Metadata-attribute glossary  | §5.5                             | Definitions of trust level, issuer, validator, registration number, etc.                                                                                                                                   |
+| References                   | §6                               | Added CX-0152 and CX-0010 (BPN identifiers)                                                                                                                                                                |
+| DSP dataset reference        | §4.3.1 / §4.4.6 / OpenAPI        | `datasetId` (jim-native, MANDATORY) — the DSP dataset under which the certificate is exposed; lets the consumer locate and negotiate it. Removed then reinstated                                           |
+| Presentation shell           | front matter, §5, annexes, legal | Versioned title, ABSTRACT, audience, terminology, annexes, copyright — sanitized of EDC/SAMM                                                                                                               |
+
+## 3 Excluded
+
+The items below are elements of the **original** that are intentionally **not** present in the combined documents.
+
+### Excluded — superseded by the CloudEvents model
+
+#### 1 — Page-based pagination
+
+**What it is (original).** Search returns a `PaginatedCertificateList` wrapper with `totalElements`, `totalPages`,
+`page`, and `pageSize`; the client navigates by page index.
+
+Instead, follow the DSP approach with cursor pagination via the HTTP `Link` header per RFC 8288 (`next`/`prev`); page
+state is an opaque token (§4.4.6.1).
+
+**Why excluded.** The two pagination models are mutually exclusive; RFC 8288 is the chosen mechanism based on alignment
+with DSP.
+
+#### 2 — `RequestStatus.UNDER_CERTIFICATION`
+
+**What it is (original).** A request status enum value indicating the certificate is being produced by an external
+authority.
+
+**jim's approach.** The equivalent Fulfillment state is `CERTIFICATION_REQUESTED` (§2.1.3), reported as the request
+`status`.
+
+**Why excluded.** Naming only — jim's term covers the same condition and is aligned with events being written in the 
+past tense.
+
+#### 3 — Request-body `certifiedBpn` and the union response shape
+
+**What it is (original).** The request body includes `certifiedBpn` (whose certificate is wanted). The response is a
+polymorphic union — `CertificateRequestInProgressResponse` / `CertificateRequestCompletedResponse` /
+`CertificateRequestRejectedResponse` — with rejection split into `requestErrors` and `locationErrors`.
+
+**jim's approach.** The request is `{ certificateType, enclosedSiteBpns }` (the certified entity is the provider
+counterparty). The response is one flat object `{ exchangeId, certificateId, version, status, errors[] }`; per-location
+errors use `errors[].specifier` (§4.4.1).
+
+**Why excluded.** jim deliberately flattens the union into a single status-dispatched object and always returns a
+correlatable `exchangeId`.
+
+#### 4 — `Header` / `FeedbackUrlHeader` envelope fields
+
+**What it is (original).** A custom message envelope with `messageId`, `context`, `sentDateTime`, `senderBpn`,
+`receiverBpn`, `relatedMessageId`, `version`, and `senderFeedbackUrl`.
+
+**jim's approach.** Messages are CloudEvents; these concerns are carried by CloudEvents attributes (`id`, `source`,
+`subject`, `time`, `type`, `relatedmessageid`, etc.) defined in CX-0000.
+
+**Why excluded.** The envelope is replaced wholesale by the CloudEvents binding.
+
+#### 5 — `PushStatus.DELETED` and `FeedbackStatus.RECEIVED`
+
+**What it is (original).** Lifecycle push uses `DELETED`; feedback uses `RECEIVED` (plus `ACCEPTED`/`REJECTED`).
+
+**jim's approach.** The lifecycle terminal is `WITHDRAWN` (§2.2.2); the acceptance non-terminal acknowledgment is
+`RETRIEVED`, and jim adds `ERRORED` to distinguish a business error from a `REJECTED` decision (§2.1.3).
+
+**Why excluded.** Naming/semantics alignment — jim's vocabulary covers more cases (separates decision from error) and 
+uses past-tense states consistently.
+
+#### 6 — Per-location error nesting (`LocationErrorCollection` / `LocationError`)
+
+**What it is (original).** Errors are nested per location: a `LocationErrorCollection` keyed by `bpn` containing
+`LocationError` entries.
+
+**jim's approach.** A flat `errors[]` array where each entry has an optional `specifier` scoping it to a BPN; if
+`specifier` is omitted the error applies to the whole certificate (§4.3.3, §4.4.5).
+
+**Why excluded.** jim's flat-with-specifier form conveys the same information with a simpler structure.
+
+#### 7 — Consolidated HTTP status table incl. `501 Not Implemented`
+
+**What it is (original).** A single table of HTTP status codes used across the API (200, 202, 400, 404, 500, 501),
+including `501 Not Implemented` for unsupported features.
+
+**jim's approach.** Error responses are documented per endpoint (200/202/400/404/500 appear where relevant); there is no
+consolidated table and no `501` as it is not needed (The DSP catalog `conformsTo` signals what is implemented).
+
+**Why excluded.** jim documents errors inline; the consolidated table and `501` were not carried over.
+
+### Excluded by the "never reference EDC" rule
+
+#### 8 — `cx-taxo:CCMAPI` EDC asset structure
+
+**What it is (original).** The Certificate Management API is offered as an EDC asset: `dct:type`/`dct:subject`,
+`cx-common:version`, a `dataAddress` (`HttpData`, proxy flags), and a rule that only one asset per (subject, version)
+may exist per BPNL.
+
+**jim's approach.** Endpoints are exposed as DSP datasets (§4.3.5, §4.4.8) described by `conformsTo` and a `http-pull`
+distribution `format` per the DSP and Data Plane Signaling Specifications, without EDC-specific asset structure.
+
+**Why excluded.** EDC-specific.
+
+#### 9 — `senderFeedbackUrl` routing mechanism
+
+**What it is (original).** A URL in the push payload telling the provider where to expect feedback, with a normative
+note that it is a temporary measure pending EDC `.well-known` support.
+
+**jim's approach.** Feedback is correlated by `exchangeId` and delivered to the provider's acceptance endpoint reached
+via the DSP dataset; no out-of-band feedback URL.
+
+**Why excluded.** EDC-coupled and superseded by the new correlation model.
+
+#### 10 — Message Flow Expectations and Business Application Provider obligations
+
+**What it is (original).** A normative bullet list of provider/consumer MUSTs (catalog exposure, access/usage policy on
+the offer, etc.) and obligations on Business Application Providers.
+
+**jim's approach.** Conformance is expressed through the per-endpoint normative requirements in §4; there is no separate
+flow-expectations list, and Business Application Provider is not a modelled role.
+
+**Why excluded.** The list is largely framed around EDC catalog/offer mechanics.
+
+#### 11 — PUSH / PULL / PUSH-then-PULL sequence diagrams
+
+**What it is (original).** Three SVG sequence diagrams depicting the EDC-mediated flows.
+
+**jim's approach.** A single Mermaid sequence diagram (§3) covering negotiation, request, fulfillment, retrieval, and
+acceptance using the DSP agent roles.
+
+**Why excluded.** The original diagrams depict EDC components and flows and no longer applies.
+
+#### 12 — EDC-proxies-4xx/5xx-as-`500` behavior note
+
+**What it is (original).** A caveat that the open-source EDC proxies any 4xx/5xx as `500`, so clients must tolerate it.
+
+**jim's approach.** Not present; jim's error semantics are described directly.
+
+**Why excluded.** EDC-specific operational behavior.
+
+### Excluded — SAMM dropped
+
+#### 13 — SAMM aspect model
+
+**What it is (original).** The certificate data model is a SAMM aspect,
+`urn:samm:io.catenax.business_partner_certificate:3.1.0`, authored in RDF/Turtle, released under CC-BY-4.0, with JSON
+Schema / AAS / docs generated by the ESMF tooling (per CX-0003).
+
+**jim's approach.** The data model is authoritative inline JSON Schema in the OpenAPI specs plus CloudEvents
+`dataschema` URLs.
+
+**Why excluded.** "CloudEvents + JSON Schema is decisive" — SAMM is not used.
+
+#### 14 — v3.1.0 BPNS/BPNA backward-compatibility note
+
+**What it is (original).** A note that the SAMM model v3.1.0 changed `enclosedSitesBpn` to accept BPNA in addition to
+BPNS, breaking backward compatibility with v3.0.0.
+
+**jim's approach.** `enclosedSites` accept BPNS or BPNA by definition; there is no SAMM versioning to reconcile.
+
+**Why excluded.** Tied to SAMM model versioning, which is not used.
+
+### Excluded — terminology prose
+
+#### 15 — Remaining domain prose
+
+**What it is (original).** Narrative subsections on registration/issuing authority, and validity guidance (use the
+issue/signature date when valid-from is absent; `31.12.9999` for no expiry).
+
+**jim's approach.** The combined doc includes the metadata-attribute glossary (§5.5) and certificate-type catalog
+(§5.4); the remaining narrative was not carried over.
+
+**Why excluded.** Lower-value prose not required to define the wire protocol.
+
+### Excluded — references and misc
+
+#### 16 — Normative refs CX-0018, CX-0003; non-normative CX-0001
+
+**What it is (original).** References to CX-0018 (Dataspace Connectivity / EDC connector conformance), CX-0003 (SAMM),
+and CX-0001 (Participant Agent Registration).
+
+**jim's approach.** References DSP directly, uses JSON Schema (not SAMM), and cites CX-0000/CX-0151 (plus the
+incorporated CX-0152 and CX-0010).
+
+**Why excluded.** CX-0018 and CX-0003 anchor EDC and SAMM respectively (both excluded); CX-0001 was not needed.
+
+#### 17 — "not replacing the existing publication semantic model" caveat
+
+**What it is (original).** A statement that the standard does not replace the existing publication semantic model.
+
+**jim's approach.** Not present; the CloudEvents proposal does not frame itself relative to the SAMM publication model.
+
+**Why excluded.** The caveat is meaningful only in the SAMM framing.
+
+### Excluded — redundant in this model
+
+#### 18 — `uploader`
+
+**What it is (original).** The original certificate metadata carries an `uploader` property — the BPNL of the business
+partner who originally provided the certificate data (for example, a company that supplied its certificate to a
+validating business application provider).
+
+**jim's approach.** The certificate is served by the Certificate Provider over its own API; the party that provides the
+certificate data is, by definition, the participant exposing it. The provider's identity is already established by the
+authenticated Dataspace Protocol interaction (and carried as the CloudEvent `source` on lifecycle and fulfillment
+events). There is therefore no separate `uploader` field.
+
+**Why excluded.** `uploader` is redundant: in this model the uploader is always the participant (the Certificate
+Provider) that exposes the certificate, so recording it as a distinct metadata property adds no information. Removed
+from
+`CertificateMetadata` and `CertificateQueryResponse` (and the §5.5 glossary) in both the combined Markdown and the
+provider OpenAPI spec.
+

--- a/docs/standards/CX-0135-CompanyCertificateManagement/certificate-consumer-notification-api-combined.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/certificate-consumer-notification-api-combined.yaml
@@ -1,0 +1,561 @@
+openapi: 3.0.3
+info:
+  title: Certificate Consumer Notification API
+  description: |
+    HTTP API exposed by a Certificate Consumer to receive notifications from
+    Certificate Providers, as defined in CX-0135 Section 4.3.
+
+    Notifications are delivered to a single endpoint and distinguished by the
+    CloudEvents `type` attribute. Two event types are defined: certificate
+    lifecycle status events (`org.catena-x.ccm.CertificateLifecycleStatus.v1`,
+    Section 4.3.1) and certificate fulfillment status notifications
+    (`org.catena-x.ccm.CertificateFulfillmentStatus.v1`, Section 4.3.2). Each
+    carries a status value in `data.status`.
+
+    All requests MUST use HTTPS (TLS 1.2 or higher). Authorization MUST adhere
+    to CX-0000 (CloudEventsFoundation) Section 4.
+  version: 1.0.0
+
+servers:
+  - url: https://{base}
+    description: Certificate Consumer base URL
+    variables:
+      base:
+        default: api.example.com
+        description: Host serving the Certificate Consumer Notification API
+
+paths:
+  /certificate-notifications:
+    post:
+      summary: Receive a certificate notification event
+      description: |
+        Invoked by a Certificate Provider to deliver a notification to the
+        Certificate Consumer. Two event types are accepted, distinguished by the
+        CloudEvents `type`: a certificate lifecycle status event and a
+        certificate fulfillment status notification. The request body is a single
+        CloudEvent or a batch (JSON array) of CloudEvents as defined in CX-0000.
+
+        For lifecycle events, only the `CREATED` status opens a Certificate
+        Exchange; `MODIFIED` and `WITHDRAWN` do not. Fulfillment notifications
+        report the Fulfillment status of an exchange the consumer opened via a
+        certificate request and are correlated by `exchangeId`.
+      operationId: postCertificateNotifications
+      requestBody:
+        required: true
+        content:
+          application/cloudevents+json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/CertificateLifecycleStatusEvent'
+                - $ref: '#/components/schemas/CertificateFulfillmentStatusEvent'
+                - type: array
+                  items:
+                    oneOf:
+                      - $ref: '#/components/schemas/CertificateLifecycleStatusEvent'
+                      - $ref: '#/components/schemas/CertificateFulfillmentStatusEvent'
+            examples:
+              created:
+                summary: Status CREATED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateLifecycleStatus.v1
+                  source: urn:bpn:BPNL0000000001AB
+                  subject: BPNL0000000002CD
+                  id: a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+                  time: "2025-05-04T07:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: CREATED
+                    datasetId: dataset-ccm-cert-abc123
+                    certificateType: ISO9001
+                    validFrom: "2023-01-25"
+                    validUntil: "2026-01-24"
+                    enclosedSiteBpns:
+                      - BPNS00000003AYRE
+                      - BPNA000000000001
+              modified:
+                summary: Status MODIFIED (new version)
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateLifecycleStatus.v1
+                  source: urn:bpn:BPNL0000000001AB
+                  subject: BPNL0000000002CD
+                  id: b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e
+                  time: "2025-08-01T07:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
+                  data:
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 2
+                    status: MODIFIED
+                    datasetId: dataset-ccm-cert-abc123
+                    certificateType: ISO9001
+                    validFrom: "2023-01-25"
+                    validUntil: "2027-01-24"
+                    enclosedSiteBpns:
+                      - BPNS00000003AYRE
+                      - BPNA000000000001
+              withdrawn:
+                summary: Status WITHDRAWN (no validity)
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateLifecycleStatus.v1
+                  source: urn:bpn:BPNL0000000001AB
+                  subject: BPNL0000000002CD
+                  id: c3d4e5f6-7a8b-9c0d-1e2f-3a4b5c6d7e8f
+                  time: "2025-09-01T07:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
+                  data:
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 2
+                    status: WITHDRAWN
+                    datasetId: dataset-ccm-cert-abc123
+                    certificateType: ISO9001
+              batch:
+                summary: A batch of lifecycle status events
+                value:
+                  - specversion: "1.0"
+                    type: org.catena-x.ccm.CertificateLifecycleStatus.v1
+                    source: urn:bpn:BPNL0000000001AB
+                    subject: BPNL0000000002CD
+                    id: a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+                    time: "2025-05-04T07:00:00Z"
+                    datacontenttype: application/json
+                    dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
+                    data:
+                      exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                      certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                      version: 1
+                      status: CREATED
+                      datasetId: dataset-ccm-cert-abc123
+                      certificateType: ISO9001
+                      validFrom: "2023-01-25"
+                      validUntil: "2026-01-24"
+                  - specversion: "1.0"
+                    type: org.catena-x.ccm.CertificateLifecycleStatus.v1
+                    source: urn:bpn:BPNL0000000001AB
+                    subject: BPNL0000000002CD
+                    id: d4e5f6a7-8b9c-0d1e-2f3a-4b5c6d7e8f90
+                    time: "2025-09-01T07:00:00Z"
+                    datacontenttype: application/json
+                    dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
+                    data:
+                      certificateId: cert-770e8400-e29b-41d4-a716-446655449999
+                      version: 3
+                      status: WITHDRAWN
+                      datasetId: dataset-ccm-cert-xyz789
+                      certificateType: ISO14001
+              fulfillmentFulfilled:
+                summary: Fulfillment status FULFILLED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateFulfillmentStatus.v1
+                  source: urn:bpn:BPNL0000000001AB
+                  subject: BPNL0000000002CD
+                  id: f0e1d2c3-b4a5-6789-0abc-def012345678
+                  time: "2025-05-04T07:30:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-fulfillment-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: FULFILLED
+              fulfillmentDeclined:
+                summary: Fulfillment status DECLINED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateFulfillmentStatus.v1
+                  source: urn:bpn:BPNL0000000001AB
+                  subject: BPNL0000000002CD
+                  id: a1c2e3f4-5b6d-7e8f-9a0b-1c2d3e4f5a6b
+                  time: "2025-05-04T07:30:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-fulfillment-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: DECLINED
+                    errors:
+                      - message: Certificate type not offered for the requested location
+      responses:
+        '204':
+          description: Event(s) accepted; response body is empty.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /certificate-acceptance-status/{id}:
+    get:
+      summary: Query the acceptance status of an exchange
+      description: |
+        Invoked by a Certificate Provider to query the current acceptance
+        status of a Certificate Exchange it opened. The `{id}` path parameter
+        MUST be the `exchangeId` assigned when the exchange was opened.
+      operationId: getCertificateAcceptanceStatus
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: |
+            The `exchangeId` of the Certificate Exchange.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: |
+            Current acceptance status of the certificate. The `status` value is
+            one of the Acceptance-phase states, including the non-terminal
+            `RETRIEVED` indicating that the certificate has been retrieved but
+            acceptance has not yet concluded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateAcceptanceStatusResponse'
+              examples:
+                retrieved:
+                  summary: Status RETRIEVED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: RETRIEVED
+                accepted:
+                  summary: Status ACCEPTED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: ACCEPTED
+                rejected:
+                  summary: Status REJECTED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: REJECTED
+                    errors:
+                      - message: Certificate has expired
+                      - specifier: BPNS000000000002
+                        message: Site BPNS000000000002 has been Rejected
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  schemas:
+    CertificateLifecycleStatusEvent:
+      type: object
+      description: |
+        CloudEvents 1.0 envelope carrying a certificate lifecycle status
+        payload. The lifecycle transition is carried in `data.status`.
+      required:
+        - specversion
+        - type
+        - source
+        - id
+        - time
+        - data
+      properties:
+        specversion:
+          type: string
+          enum: ["1.0"]
+          description: The CloudEvents specification version.
+        type:
+          type: string
+          enum: [org.catena-x.ccm.CertificateLifecycleStatus.v1]
+          description: The event type identifier.
+        source:
+          type: string
+          format: uri
+          description: |
+            URI identifying the producing Certificate Provider. Typically a
+            BPN-scoped URN (for example, `urn:bpn:BPNL0000000001AB`).
+        subject:
+          type: string
+          description: |
+            The BPN of the recipient (Certificate Consumer) the event is
+            addressed to.
+        id:
+          type: string
+          description: Unique identifier of this event instance.
+        time:
+          type: string
+          format: date-time
+          description: RFC 3339 timestamp at which the event was produced.
+        datacontenttype:
+          type: string
+          enum: [application/json]
+          description: Content type of the `data` member.
+        dataschema:
+          type: string
+          format: uri
+          description: URI of the JSON Schema describing the `data` payload.
+        data:
+          $ref: '#/components/schemas/CertificateLifecycleStatus'
+
+    CertificateStatusBase:
+      type: object
+      description: |
+        Common certificate-status base payload. Carries the `exchangeId` (when
+        the event belongs to a Certificate Exchange), the subject `certificateId`,
+        and a `status`. Concrete event payloads derive from this schema and
+        constrain `status` to the values defined for their endpoint.
+      required:
+        - certificateId
+        - status
+      properties:
+        exchangeId:
+          type: string
+          description: |
+            Identifier of the Certificate Exchange the event belongs to. Distinct
+            from the CloudEvent `id`. Present when the event pertains to an
+            exchange; subtypes may require it.
+        certificateId:
+          type: string
+          description: |
+            Unique identifier of the certificate the status applies to, usable
+            in `GET /certificates/{id}` on the Certificate Provider API.
+        status:
+          type: string
+          description: |
+            The status value. Subtypes constrain the permitted set of values.
+
+    CertificateLifecycleStatus:
+      description: |
+        Certificate lifecycle status payload, derived from `CertificateStatusBase`.
+        `exchangeId` is present when `status` is `CREATED` (the event opens the
+        exchange) and absent for `MODIFIED`/`WITHDRAWN`. `validFrom` and
+        `validUntil` are REQUIRED when `status` is `CREATED` or `MODIFIED` and MAY
+        be omitted when `status` is `WITHDRAWN`.
+      allOf:
+        - $ref: '#/components/schemas/CertificateStatusBase'
+        - type: object
+          required:
+            - version
+            - datasetId
+            - certificateType
+          properties:
+            version:
+              type: integer
+              description: |
+                Version of the certificate. Together with `certificateId` it
+                identifies the specific certificate.
+            status:
+              type: string
+              enum: [CREATED, MODIFIED, WITHDRAWN]
+              description: |
+                The lifecycle status. `CREATED` opens a Certificate Exchange;
+                `MODIFIED` and `WITHDRAWN` do not.
+            datasetId:
+              type: string
+              description: |
+                Identifier of the DSP dataset under which the certificate is
+                exposed in the Certificate Provider's catalog, enabling the
+                consumer to locate and negotiate the certificate via the
+                Dataspace Protocol.
+            certificateType:
+              type: string
+              description: Opaque string identifying the certificate type (e.g. `ISO9001`).
+            validFrom:
+              type: string
+              format: date
+              description: |
+                Inclusive start date of the validity period (ISO 8601 full-date,
+                `YYYY-MM-DD`). Required when `status` is `CREATED` or `MODIFIED`.
+            validUntil:
+              type: string
+              format: date
+              description: |
+                Inclusive end date of the validity period (ISO 8601 full-date,
+                `YYYY-MM-DD`). Same presence rules as `validFrom`.
+            enclosedSiteBpns:
+              type: array
+              description: |
+                BPNs of the sites or addresses the certificate applies to. If
+                omitted, the certificate applies to the issuing legal entity as a
+                whole.
+              items:
+                type: string
+
+    CertificateFulfillmentStatusEvent:
+      type: object
+      description: |
+        CloudEvents 1.0 envelope carrying a certificate fulfillment status
+        notification. The Fulfillment-phase status is carried in `data.status`.
+      required:
+        - specversion
+        - type
+        - source
+        - id
+        - time
+        - data
+      properties:
+        specversion:
+          type: string
+          enum: ["1.0"]
+          description: The CloudEvents specification version.
+        type:
+          type: string
+          enum: [org.catena-x.ccm.CertificateFulfillmentStatus.v1]
+          description: The event type identifier.
+        source:
+          type: string
+          format: uri
+          description: |
+            URI identifying the producing Certificate Provider. Typically a
+            BPN-scoped URN (for example, `urn:bpn:BPNL0000000001AB`).
+        subject:
+          type: string
+          description: |
+            The BPN of the recipient (Certificate Consumer) the event is
+            addressed to.
+        id:
+          type: string
+          description: Unique identifier of this event instance.
+        time:
+          type: string
+          format: date-time
+          description: RFC 3339 timestamp at which the event was produced.
+        datacontenttype:
+          type: string
+          enum: [application/json]
+          description: Content type of the `data` member.
+        dataschema:
+          type: string
+          format: uri
+          description: URI of the JSON Schema describing the `data` payload.
+        data:
+          $ref: '#/components/schemas/CertificateFulfillmentStatus'
+
+    CertificateFulfillmentStatus:
+      description: |
+        Certificate fulfillment status payload, derived from
+        `CertificateStatusBase`. Reports the Fulfillment-phase status of a
+        consumer-initiated Certificate Exchange and is correlated by the
+        required `exchangeId`. It is the push counterpart of the
+        `GET /certificate-requests/{id}` poll on the Certificate Provider API.
+      allOf:
+        - $ref: '#/components/schemas/CertificateStatusBase'
+        - type: object
+          required:
+            - exchangeId
+          properties:
+            status:
+              type: string
+              enum: [ACKNOWLEDGED, CERTIFICATION_REQUESTED, FULFILLED, DECLINED, FAILED]
+              description: |
+                The Fulfillment status. Providers SHOULD push at least the
+                terminal outcomes (`FULFILLED`, `DECLINED`, `FAILED`);
+                intermediate states MAY also be pushed.
+            errors:
+              type: array
+              description: |
+                Error details. MUST be present and non-empty when `status` is
+                `DECLINED` or `FAILED`; otherwise absent.
+              items:
+                $ref: '#/components/schemas/StatusError'
+
+    CertificateAcceptanceStatusResponse:
+      description: |
+        Current acceptance status of a Certificate Exchange on the Certificate
+        Consumer, derived from `CertificateStatusBase`. The `status` property
+        conveys the Acceptance-phase state, including the non-terminal
+        `RETRIEVED` value.
+      allOf:
+        - $ref: '#/components/schemas/CertificateStatusBase'
+        - type: object
+          required:
+            - exchangeId
+          properties:
+            status:
+              type: string
+              enum: [RETRIEVED, ACCEPTED, REJECTED, ERRORED]
+              description: The current acceptance status.
+            errors:
+              type: array
+              description: |
+                Error details. MUST NOT be present when `status` is `RETRIEVED`
+                or `ACCEPTED`. MUST be present and non-empty when `status` is
+                `REJECTED` or `ERRORED`.
+              items:
+                $ref: '#/components/schemas/StatusError'
+
+    StatusError:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Human-readable description of the error.
+        specifier:
+          type: string
+          description: |
+            Optional identifier scoping the error to a particular element of
+            the certificate, such as a site BPN. If omitted, the error
+            applies to the certificate as a whole.
+
+    Error:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Human-readable error description.
+
+  responses:
+    BadRequest:
+      description: The request was malformed or failed validation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: The request was not authenticated.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Forbidden:
+      description: The caller is not authorized to perform this operation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: |
+        The referenced certificate is unknown to the Certificate Consumer.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    InternalServerError:
+      description: An unexpected error occurred on the server.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        Bearer token as defined by CX-0000 Section 4 (HTTPS Binding).
+
+security:
+  - bearerAuth: []

--- a/docs/standards/CX-0135-CompanyCertificateManagement/certificate-consumer-notification-api-jim.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/certificate-consumer-notification-api-jim.yaml
@@ -1,0 +1,559 @@
+openapi: 3.0.3
+info:
+  title: Certificate Consumer Notification API
+  description: |
+    HTTP API exposed by a Certificate Consumer to receive notifications from
+    Certificate Providers, as defined in CX-0135 Section 4.3.
+
+    Notifications are delivered to a single endpoint and distinguished by the
+    CloudEvents `type` attribute. Two event types are defined: certificate
+    lifecycle status events (`org.catena-x.ccm.CertificateLifecycleStatus.v1`,
+    Section 4.3.1) and certificate fulfillment status notifications
+    (`org.catena-x.ccm.CertificateFulfillmentStatus.v1`, Section 4.3.2). Each
+    carries a status value in `data.status`.
+
+    All requests MUST use HTTPS (TLS 1.2 or higher). Authorization MUST adhere
+    to CX-0000 (CloudEventsFoundation) Section 4.
+  version: 1.0.0
+
+servers:
+  - url: https://{base}
+    description: Certificate Consumer base URL
+    variables:
+      base:
+        default: api.example.com
+        description: Host serving the Certificate Consumer Notification API
+
+paths:
+  /certificate-notifications:
+    post:
+      summary: Receive a certificate notification event
+      description: |
+        Invoked by a Certificate Provider to deliver a notification to the
+        Certificate Consumer. Two event types are accepted, distinguished by the
+        CloudEvents `type`: a certificate lifecycle status event and a
+        certificate fulfillment status notification. The request body is a single
+        CloudEvent or a batch (JSON array) of CloudEvents as defined in CX-0000.
+
+        For lifecycle events, only the `CREATED` status opens a Certificate
+        Exchange; `MODIFIED` and `WITHDRAWN` do not. Fulfillment notifications
+        report the Fulfillment status of an exchange the consumer opened via a
+        certificate request and are correlated by `exchangeId`.
+      operationId: postCertificateNotifications
+      requestBody:
+        required: true
+        content:
+          application/cloudevents+json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/CertificateLifecycleStatusEvent'
+                - $ref: '#/components/schemas/CertificateFulfillmentStatusEvent'
+                - type: array
+                  items:
+                    oneOf:
+                      - $ref: '#/components/schemas/CertificateLifecycleStatusEvent'
+                      - $ref: '#/components/schemas/CertificateFulfillmentStatusEvent'
+            examples:
+              created:
+                summary: Status CREATED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateLifecycleStatus.v1
+                  source: urn:bpn:BPNL0000000001AB
+                  subject: BPNL0000000002CD
+                  id: a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+                  time: "2025-05-04T07:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: CREATED
+                    datasetId: dataset-ccm-cert-abc123
+                    certificateType: ISO9001
+                    validFrom: "2023-01-25"
+                    validUntil: "2026-01-24"
+                    locationBpns:
+                      - BPNS00000003AYRE
+                      - BPNA000000000001
+              modified:
+                summary: Status MODIFIED (new version)
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateLifecycleStatus.v1
+                  source: urn:bpn:BPNL0000000001AB
+                  subject: BPNL0000000002CD
+                  id: b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e
+                  time: "2025-08-01T07:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
+                  data:
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 2
+                    status: MODIFIED
+                    datasetId: dataset-ccm-cert-abc123
+                    certificateType: ISO9001
+                    validFrom: "2023-01-25"
+                    validUntil: "2027-01-24"
+                    locationBpns:
+                      - BPNS00000003AYRE
+                      - BPNA000000000001
+              withdrawn:
+                summary: Status WITHDRAWN (no validity)
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateLifecycleStatus.v1
+                  source: urn:bpn:BPNL0000000001AB
+                  subject: BPNL0000000002CD
+                  id: c3d4e5f6-7a8b-9c0d-1e2f-3a4b5c6d7e8f
+                  time: "2025-09-01T07:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
+                  data:
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 2
+                    status: WITHDRAWN
+                    datasetId: dataset-ccm-cert-abc123
+                    certificateType: ISO9001
+              batch:
+                summary: A batch of lifecycle status events
+                value:
+                  - specversion: "1.0"
+                    type: org.catena-x.ccm.CertificateLifecycleStatus.v1
+                    source: urn:bpn:BPNL0000000001AB
+                    subject: BPNL0000000002CD
+                    id: a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+                    time: "2025-05-04T07:00:00Z"
+                    datacontenttype: application/json
+                    dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
+                    data:
+                      exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                      certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                      version: 1
+                      status: CREATED
+                      datasetId: dataset-ccm-cert-abc123
+                      certificateType: ISO9001
+                      validFrom: "2023-01-25"
+                      validUntil: "2026-01-24"
+                  - specversion: "1.0"
+                    type: org.catena-x.ccm.CertificateLifecycleStatus.v1
+                    source: urn:bpn:BPNL0000000001AB
+                    subject: BPNL0000000002CD
+                    id: d4e5f6a7-8b9c-0d1e-2f3a-4b5c6d7e8f90
+                    time: "2025-09-01T07:00:00Z"
+                    datacontenttype: application/json
+                    dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
+                    data:
+                      certificateId: cert-770e8400-e29b-41d4-a716-446655449999
+                      version: 3
+                      status: WITHDRAWN
+                      datasetId: dataset-ccm-cert-xyz789
+                      certificateType: ISO14001
+              fulfillmentFulfilled:
+                summary: Fulfillment status FULFILLED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateFulfillmentStatus.v1
+                  source: urn:bpn:BPNL0000000001AB
+                  subject: BPNL0000000002CD
+                  id: f0e1d2c3-b4a5-6789-0abc-def012345678
+                  time: "2025-05-04T07:30:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-fulfillment-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: FULFILLED
+              fulfillmentDeclined:
+                summary: Fulfillment status DECLINED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateFulfillmentStatus.v1
+                  source: urn:bpn:BPNL0000000001AB
+                  subject: BPNL0000000002CD
+                  id: a1c2e3f4-5b6d-7e8f-9a0b-1c2d3e4f5a6b
+                  time: "2025-05-04T07:30:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-fulfillment-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: DECLINED
+                    errors:
+                      - message: Certificate type not offered for the requested location
+      responses:
+        '204':
+          description: Event(s) accepted; response body is empty.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /certificate-acceptance-status/{id}:
+    get:
+      summary: Query the acceptance status of an exchange
+      description: |
+        Invoked by a Certificate Provider to query the current acceptance
+        status of a Certificate Exchange it opened. The `{id}` path parameter
+        MUST be the `exchangeId` assigned when the exchange was opened.
+      operationId: getCertificateAcceptanceStatus
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: |
+            The `exchangeId` of the Certificate Exchange.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: |
+            Current acceptance status of the certificate. The `status` value is
+            one of the Acceptance-phase states, including the non-terminal
+            `RETRIEVED` indicating that the certificate has been retrieved but
+            acceptance has not yet concluded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateAcceptanceStatusResponse'
+              examples:
+                retrieved:
+                  summary: Status RETRIEVED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: RETRIEVED
+                accepted:
+                  summary: Status ACCEPTED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: ACCEPTED
+                rejected:
+                  summary: Status REJECTED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: REJECTED
+                    errors:
+                      - message: Certificate has expired
+                      - specifier: BPNS000000000002
+                        message: Site BPNS000000000002 has been Rejected
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  schemas:
+    CertificateLifecycleStatusEvent:
+      type: object
+      description: |
+        CloudEvents 1.0 envelope carrying a certificate lifecycle status
+        payload. The lifecycle transition is carried in `data.status`.
+      required:
+        - specversion
+        - type
+        - source
+        - id
+        - time
+        - data
+      properties:
+        specversion:
+          type: string
+          enum: ["1.0"]
+          description: The CloudEvents specification version.
+        type:
+          type: string
+          enum: [org.catena-x.ccm.CertificateLifecycleStatus.v1]
+          description: The event type identifier.
+        source:
+          type: string
+          format: uri
+          description: |
+            URI identifying the producing Certificate Provider. Typically a
+            BPN-scoped URN (for example, `urn:bpn:BPNL0000000001AB`).
+        subject:
+          type: string
+          description: |
+            The BPN of the recipient (Certificate Consumer) the event is
+            addressed to.
+        id:
+          type: string
+          description: Unique identifier of this event instance.
+        time:
+          type: string
+          format: date-time
+          description: RFC 3339 timestamp at which the event was produced.
+        datacontenttype:
+          type: string
+          enum: [application/json]
+          description: Content type of the `data` member.
+        dataschema:
+          type: string
+          format: uri
+          description: URI of the JSON Schema describing the `data` payload.
+        data:
+          $ref: '#/components/schemas/CertificateLifecycleStatus'
+
+    CertificateStatusBase:
+      type: object
+      description: |
+        Common certificate-status base payload. Carries the `exchangeId` (when
+        the event belongs to a Certificate Exchange), the subject `certificateId`,
+        and a `status`. Concrete event payloads derive from this schema and
+        constrain `status` to the values defined for their endpoint.
+      required:
+        - certificateId
+        - status
+      properties:
+        exchangeId:
+          type: string
+          description: |
+            Identifier of the Certificate Exchange the event belongs to. Distinct
+            from the CloudEvent `id`. Present when the event pertains to an
+            exchange; subtypes may require it.
+        certificateId:
+          type: string
+          description: |
+            Unique identifier of the certificate the status applies to, usable
+            in `GET /certificates/{id}` on the Certificate Provider API.
+        status:
+          type: string
+          description: |
+            The status value. Subtypes constrain the permitted set of values.
+
+    CertificateLifecycleStatus:
+      description: |
+        Certificate lifecycle status payload, derived from `CertificateStatusBase`.
+        `exchangeId` is present when `status` is `CREATED` (the event opens the
+        exchange) and absent for `MODIFIED`/`WITHDRAWN`. `validFrom` and
+        `validUntil` are REQUIRED when `status` is `CREATED` or `MODIFIED` and MAY
+        be omitted when `status` is `WITHDRAWN`.
+      allOf:
+        - $ref: '#/components/schemas/CertificateStatusBase'
+        - type: object
+          required:
+            - version
+            - datasetId
+            - certificateType
+          properties:
+            version:
+              type: integer
+              description: |
+                Version of the certificate. Together with `certificateId` it
+                identifies the specific certificate.
+            status:
+              type: string
+              enum: [CREATED, MODIFIED, WITHDRAWN]
+              description: |
+                The lifecycle status. `CREATED` opens a Certificate Exchange;
+                `MODIFIED` and `WITHDRAWN` do not.
+            datasetId:
+              type: string
+              description: |
+                Identifier of the DSP dataset under which the certificate is
+                exposed in the Certificate Provider's catalog.
+            certificateType:
+              type: string
+              description: Opaque string identifying the certificate type (e.g. `ISO9001`).
+            validFrom:
+              type: string
+              format: date
+              description: |
+                Inclusive start date of the validity period (ISO 8601 full-date,
+                `YYYY-MM-DD`). Required when `status` is `CREATED` or `MODIFIED`.
+            validUntil:
+              type: string
+              format: date
+              description: |
+                Inclusive end date of the validity period (ISO 8601 full-date,
+                `YYYY-MM-DD`). Same presence rules as `validFrom`.
+            locationBpns:
+              type: array
+              description: |
+                BPNs of the sites or addresses the certificate applies to. If
+                omitted, the certificate applies to the issuing legal entity as a
+                whole.
+              items:
+                type: string
+
+    CertificateFulfillmentStatusEvent:
+      type: object
+      description: |
+        CloudEvents 1.0 envelope carrying a certificate fulfillment status
+        notification. The Fulfillment-phase status is carried in `data.status`.
+      required:
+        - specversion
+        - type
+        - source
+        - id
+        - time
+        - data
+      properties:
+        specversion:
+          type: string
+          enum: ["1.0"]
+          description: The CloudEvents specification version.
+        type:
+          type: string
+          enum: [org.catena-x.ccm.CertificateFulfillmentStatus.v1]
+          description: The event type identifier.
+        source:
+          type: string
+          format: uri
+          description: |
+            URI identifying the producing Certificate Provider. Typically a
+            BPN-scoped URN (for example, `urn:bpn:BPNL0000000001AB`).
+        subject:
+          type: string
+          description: |
+            The BPN of the recipient (Certificate Consumer) the event is
+            addressed to.
+        id:
+          type: string
+          description: Unique identifier of this event instance.
+        time:
+          type: string
+          format: date-time
+          description: RFC 3339 timestamp at which the event was produced.
+        datacontenttype:
+          type: string
+          enum: [application/json]
+          description: Content type of the `data` member.
+        dataschema:
+          type: string
+          format: uri
+          description: URI of the JSON Schema describing the `data` payload.
+        data:
+          $ref: '#/components/schemas/CertificateFulfillmentStatus'
+
+    CertificateFulfillmentStatus:
+      description: |
+        Certificate fulfillment status payload, derived from
+        `CertificateStatusBase`. Reports the Fulfillment-phase status of a
+        consumer-initiated Certificate Exchange and is correlated by the
+        required `exchangeId`. It is the push counterpart of the
+        `GET /certificate-requests/{id}` poll on the Certificate Provider API.
+      allOf:
+        - $ref: '#/components/schemas/CertificateStatusBase'
+        - type: object
+          required:
+            - exchangeId
+          properties:
+            status:
+              type: string
+              enum: [ACKNOWLEDGED, CERTIFICATION_REQUESTED, FULFILLED, DECLINED, FAILED]
+              description: |
+                The Fulfillment status. Providers SHOULD push at least the
+                terminal outcomes (`FULFILLED`, `DECLINED`, `FAILED`);
+                intermediate states MAY also be pushed.
+            errors:
+              type: array
+              description: |
+                Error details. MUST be present and non-empty when `status` is
+                `DECLINED` or `FAILED`; otherwise absent.
+              items:
+                $ref: '#/components/schemas/StatusError'
+
+    CertificateAcceptanceStatusResponse:
+      description: |
+        Current acceptance status of a Certificate Exchange on the Certificate
+        Consumer, derived from `CertificateStatusBase`. The `status` property
+        conveys the Acceptance-phase state, including the non-terminal
+        `RETRIEVED` value.
+      allOf:
+        - $ref: '#/components/schemas/CertificateStatusBase'
+        - type: object
+          required:
+            - exchangeId
+          properties:
+            status:
+              type: string
+              enum: [RETRIEVED, ACCEPTED, REJECTED, ERRORED]
+              description: The current acceptance status.
+            errors:
+              type: array
+              description: |
+                Error details. MUST NOT be present when `status` is `RETRIEVED`
+                or `ACCEPTED`. MUST be present and non-empty when `status` is
+                `REJECTED` or `ERRORED`.
+              items:
+                $ref: '#/components/schemas/StatusError'
+
+    StatusError:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Human-readable description of the error.
+        specifier:
+          type: string
+          description: |
+            Optional identifier scoping the error to a particular element of
+            the certificate, such as a site BPN. If omitted, the error
+            applies to the certificate as a whole.
+
+    Error:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Human-readable error description.
+
+  responses:
+    BadRequest:
+      description: The request was malformed or failed validation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: The request was not authenticated.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Forbidden:
+      description: The caller is not authorized to perform this operation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: |
+        The referenced certificate is unknown to the Certificate Consumer.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    InternalServerError:
+      description: An unexpected error occurred on the server.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        Bearer token as defined by CX-0000 Section 4 (HTTPS Binding).
+
+security:
+  - bearerAuth: []

--- a/docs/standards/CX-0135-CompanyCertificateManagement/certificate-provider-api-combined.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/certificate-provider-api-combined.yaml
@@ -1,0 +1,965 @@
+openapi: 3.0.3
+info:
+  title: Certificate Provider API
+  description: |
+    HTTP API exposed by a Certificate Provider to accept certificate requests,
+    report request fulfillment status, serve certificate data, accept
+    acceptance status updates, and answer certificate queries, as defined in
+    CX-0135 Section 4.4.
+
+    A certificate is identified by the (`certificateId`, `version`) pair. A
+    consumer-initiated request opens a Certificate Exchange; the Certificate
+    Provider assigns `certificateId` and `version` when it accepts the request.
+
+    All requests MUST use HTTPS (TLS 1.2 or higher). Authorization MUST adhere
+    to CX-0000 (CloudEventsFoundation) Section 4.
+  version: 1.0.0
+
+servers:
+  - url: https://{base}
+    description: Certificate Provider base URL
+    variables:
+      base:
+        default: api.example.com
+        description: Host serving the Certificate Provider API
+
+paths:
+  /certificate-requests:
+    post:
+      summary: Request a certificate
+      description: |
+        Invoked by a Certificate Consumer to request a certificate. A request
+        opens a consumer-initiated Certificate Exchange. On acceptance the
+        Certificate Provider assigns and returns a `certificateId` and
+        `version`, enabling the consumer to poll fulfillment status and later
+        retrieve the certificate.
+      operationId: createCertificateRequest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CertificateRequest'
+            examples:
+              byType:
+                summary: Request a certificate by type and location
+                value:
+                  certificateType: ISO9001
+                  enclosedSiteBpns:
+                    - BPNS00000003AYRE
+      responses:
+        '202':
+          description: |
+            The request was accepted. The body carries the assigned
+            `certificateId` and `version` and the current fulfillment status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateRequestResponse'
+              examples:
+                acknowledged:
+                  summary: Accepted for asynchronous fulfillment
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: ACKNOWLEDGED
+                fulfilled:
+                  summary: Certificate already available
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: FULFILLED
+                declined:
+                  summary: Request refused
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: DECLINED
+                    errors:
+                      - message: Certificate type not offered for the requested location
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /certificate-requests/{id}:
+    get:
+      summary: Poll the fulfillment status of a request
+      description: |
+        Invoked by a Certificate Consumer to poll the fulfillment status of a
+        previously submitted certificate request. This endpoint reports only the
+        Fulfillment phase; the consumer's acceptance outcome is reported
+        separately via `POST /certificate-acceptance-notifications`.
+
+        Polling is optional: if the Certificate Consumer exposes the Certificate
+        Consumer Notification API, the Certificate Provider MAY instead push
+        these fulfillment status updates to it as a
+        `org.catena-x.ccm.CertificateFulfillmentStatus.v1` event (CX-0135
+        Section 4.3.2). The push and the poll are equivalent and carry the same
+        `exchangeId` and `status`.
+      operationId: getCertificateRequestStatus
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: |
+            The `exchangeId` returned in the response to the certificate
+            request.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current fulfillment status of the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateRequestStatus'
+              examples:
+                acknowledged:
+                  summary: Status ACKNOWLEDGED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: ACKNOWLEDGED
+                fulfilled:
+                  summary: Status FULFILLED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: FULFILLED
+                declined:
+                  summary: Status DECLINED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: DECLINED
+                    errors:
+                      - message: Certificate type not offered for the requested location
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /certificates/{id}:
+    get:
+      summary: Retrieve certificate metadata
+      description: |
+        Retrieves the metadata of a certificate as `application/json`. The
+        certificate is metadata only; binary documents are not included. Each
+        associated document is listed by reference in the `documents` array and
+        retrieved independently via `GET /documents/{id}`.
+        Returns the latest version by default; a specific version may be
+        requested with the `version` query parameter (e.g. to retrieve the exact
+        version a Certificate Exchange concerns). The provider MUST be able to
+        return any version still referenced by a non-terminal Certificate
+        Exchange.
+      operationId: getCertificate
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The unique identifier of the certificate.
+          schema:
+            type: string
+        - name: version
+          in: query
+          required: false
+          description: |
+            The specific version to retrieve. If omitted, the latest version is
+            returned.
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: |
+            Certificate found. The response is the JSON metadata described by
+            `CertificateMetadata`, including the `documents` array referencing
+            the documents associated with the returned version.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateMetadata'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /documents/{id}:
+    get:
+      summary: Retrieve a certificate document
+      description: |
+        Retrieves a certificate document by its identifier. The response body is
+        the document binary, served directly with the `Content-Type` set to the
+        document's `mediaType` (e.g. `application/pdf`) as advertised in the
+        certificate metadata.
+        A `documentId` is opaque and independent of any certificate version; the
+        same document may be referenced by multiple certificate versions, so no
+        `version` parameter is required.
+      operationId: getDocument
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The opaque, version-independent identifier of the document.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: |
+            Document found. The response body is the document binary, served with
+            the `Content-Type` set to the document's `mediaType`.
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /certificate-acceptance-notifications:
+    post:
+      summary: Submit a certificate acceptance status event
+      description: |
+        Invoked by a Certificate Consumer to report the acceptance status of a
+        certificate. The status is carried in `data.status` and the Certificate
+        Provider dispatches on it. The event is correlated to its Certificate
+        Exchange by the `exchangeId` in `data`. Acceptance MUST reference an
+        existing exchange (opened by a consumer request or a provider
+        notification); merely retrieving a certificate does not establish an
+        exchange. An unknown `exchangeId` is rejected with 404. The body is a
+        single CloudEvent or a batch (JSON array).
+      operationId: postCertificateAcceptanceNotification
+      requestBody:
+        required: true
+        content:
+          application/cloudevents+json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/CertificateAcceptanceStatusEvent'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/CertificateAcceptanceStatusEvent'
+            examples:
+              retrieved:
+                summary: Status RETRIEVED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateAcceptanceStatus.v1
+                  source: urn:bpn:BPNL0000000002CD
+                  subject: BPNL0000000001AB
+                  id: e9f8d7c6-b5a4-9382-7160-5a4b3c2d1e0f
+                  time: "2025-05-04T08:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: RETRIEVED
+              accepted:
+                summary: Status ACCEPTED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateAcceptanceStatus.v1
+                  source: urn:bpn:BPNL0000000002CD
+                  subject: BPNL0000000001AB
+                  id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d
+                  time: "2025-05-04T09:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: ACCEPTED
+              rejected:
+                summary: Status REJECTED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateAcceptanceStatus.v1
+                  source: urn:bpn:BPNL0000000002CD
+                  subject: BPNL0000000001AB
+                  id: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
+                  time: "2025-05-04T09:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: REJECTED
+                    errors:
+                      - message: Certificate has expired
+                      - message: Unexpected data format
+                      - specifier: BPNS000000000002
+                        message: Site BPNS000000000002 has been Rejected
+              errored:
+                summary: Status ERRORED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateAcceptanceStatus.v1
+                  source: urn:bpn:BPNL0000000002CD
+                  subject: BPNL0000000001AB
+                  id: c8d7e6f5-a4b3-2109-8765-432109fedcba
+                  time: "2025-05-04T08:30:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: ERRORED
+                    errors:
+                      - message: Certificate document is malformed and cannot be validated
+      responses:
+        '204':
+          description: Acceptance status accepted; response body is empty.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /certificates/search:
+    post:
+      summary: Search certificates
+      description: |
+        Returns certificates matching the supplied criteria. Results MAY be
+        paginated; when paginated, navigation URLs are provided in the `Link`
+        response header in accordance with RFC 8288 (Web Linking). Only the
+        `next` and `prev` link relations are guaranteed; `first` and `last`
+        MAY also be returned. To retrieve a subsequent page, the client
+        re-issues a `POST` with the same request body against the URL
+        provided in the corresponding `Link` value.
+      operationId: queryCertificates
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CertificateQuery'
+            examples:
+              byType:
+                summary: Query by certificate type and validity window
+                value:
+                  certificateType: ISO9001
+                  from: "2023-01-25"
+                  to: "2026-01-24"
+                  limit: 50
+      responses:
+        '200':
+          description: |
+            Matching certificates. When the result set is paginated, the
+            response includes a `Link` header per RFC 8288.
+          headers:
+            Link:
+              description: |
+                Web Linking pagination header (RFC 8288). Contains URLs for
+                the `next` and/or `prev` pages. Omitted when the response is
+                not paginated.
+              schema:
+                type: string
+              example: >-
+                <https://provider.example.com/certificates/search?cursor=eyJvZmZzZXQiOjUwfQ>; rel="next",
+                <https://provider.example.com/certificates/search?cursor=eyJvZmZzZXQiOjB9>; rel="prev"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CertificateQueryResponse'
+              examples:
+                page:
+                  summary: A single page of results
+                  value:
+                    - certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                      version: 1
+                      datasetId: dataset-ccm-cert-abc123
+                      certificateType: ISO9001
+                      validFrom: "2023-01-25"
+                      validUntil: "2026-01-24"
+                      enclosedSiteBpns:
+                        - BPNS00000003AYRE
+                        - BPNA000000000001
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  schemas:
+    CertificateRequest:
+      type: object
+      description: Request body for `POST /certificate-requests`.
+      required:
+        - certificateType
+      properties:
+        certificateType:
+          type: string
+          description: |
+            Opaque string identifying the certificate type to be requested
+            (for example, `ISO9001`).
+        enclosedSiteBpns:
+          type: array
+          description: |
+            BPNs of the sites or addresses the request applies to. If omitted,
+            the request applies to the legal entity.
+          items:
+            type: string
+
+    CertificateRequestResponse:
+      type: object
+      description: |
+        Response to an accepted certificate request. Carries the assigned
+        exchange and certificate identity and the initial fulfillment status.
+      required:
+        - exchangeId
+        - certificateId
+        - version
+        - status
+      properties:
+        exchangeId:
+          type: string
+          description: |
+            Identifier assigned to the opened Certificate Exchange. Used to poll
+            fulfillment status via `GET /certificate-requests/{id}`.
+        certificateId:
+          type: string
+          description: |
+            Identifier assigned to the requested certificate. Used to retrieve
+            the certificate via `GET /certificates/{id}`.
+        version:
+          type: integer
+          description: Version assigned to the requested certificate.
+        status:
+          type: string
+          enum: [ACKNOWLEDGED, CERTIFICATION_REQUESTED, FULFILLED, DECLINED]
+          description: The fulfillment status of the request.
+        errors:
+          type: array
+          description: |
+            Error details. MUST be present and non-empty when `status` is
+            `DECLINED`.
+          items:
+            $ref: '#/components/schemas/StatusError'
+
+    CertificateRequestStatus:
+      type: object
+      description: |
+        Current fulfillment status of a certificate request.
+      required:
+        - exchangeId
+        - certificateId
+        - version
+        - status
+      properties:
+        exchangeId:
+          type: string
+          description: |
+            Identifier of the Certificate Exchange. Matches the `{id}` path
+            parameter of the request.
+        certificateId:
+          type: string
+          description: Unique identifier of the requested certificate.
+        version:
+          type: integer
+          description: The version of the requested certificate.
+        status:
+          type: string
+          enum: [ACKNOWLEDGED, CERTIFICATION_REQUESTED, FULFILLED, DECLINED, FAILED]
+          description: The current fulfillment status.
+        errors:
+          type: array
+          description: |
+            Error details. MUST be present and non-empty when `status` is
+            `DECLINED` or `FAILED`.
+          items:
+            $ref: '#/components/schemas/StatusError'
+
+    CertificateDocument:
+      type: object
+      description: |
+        A reference to a document associated with a certificate version. The
+        binary is retrieved separately via `GET /documents/{id}`.
+      required:
+        - documentId
+        - mediaType
+      properties:
+        documentId:
+          type: string
+          description: |
+            Opaque, version-independent identifier of the document, used to
+            retrieve it via `GET /documents/{id}`.
+          examples:
+            - "doc-3fa85f64-5717-4562-b3fc-2c963f66afa6"
+        language:
+          type: string
+          description: |
+            Language of the document as an ISO 639-1 two-letter code
+            (e.g. `en` for English, `de` for German). Distinguishes documents
+            that differ only by language.
+          pattern: "^[a-z]{2}$"
+          examples:
+            - "en"
+        mediaType:
+          type: string
+          description: IANA media type of the document binary.
+          examples:
+            - "application/pdf"
+            - "image/png"
+
+    EnclosedSite:
+      type: object
+      description: A site or address a certificate applies to.
+      required:
+        - bpn
+      properties:
+        bpn:
+          type: string
+          description: |
+            The Business Partner Number of the site (BPNS) or address (BPNA)
+            the certificate covers.
+          pattern: "^BPN[SA][a-zA-Z0-9]{12}$"
+        areaOfApplication:
+          type: string
+          description: |
+            Free-text detail of the areas or application types the certificate
+            is valid for at this specific location.
+
+    CertificateIssuer:
+      type: object
+      description: The authority that issued the certificate.
+      required:
+        - issuerName
+      properties:
+        issuerName:
+          type: string
+          description: The name of the issuing authority (e.g. `TÜV Süd`).
+        issuerBpn:
+          type: string
+          description: The BPNL of the issuing authority, if a Catena-X business partner.
+          pattern: "^BPNL[a-zA-Z0-9]{12}$"
+
+    CertificateValidator:
+      type: object
+      description: The party that can validate the certificate information.
+      required:
+        - validatorName
+      properties:
+        validatorName:
+          type: string
+          description: The name of the validator.
+        validatorBpn:
+          type: string
+          description: |
+            The BPNL of the validator. MAY be used as a free-text identifier
+            where a BPNL is not available.
+
+    CertificateMetadata:
+      type: object
+      description: JSON metadata accompanying a retrieved certificate.
+      required:
+        - certificateId
+        - version
+        - certificateType
+        - certifiedBpn
+        - registrationNumber
+        - validFrom
+        - validUntil
+        - trustLevel
+      properties:
+        certificateId:
+          type: string
+          description: |
+            Unique identifier of the certificate. Matches the `{id}` path
+            parameter of the request.
+        version:
+          type: integer
+          description: |
+            The version returned — the version requested via the `version` query
+            parameter, or the latest version if none was specified.
+        certificateType:
+          type: string
+          description: Opaque string identifying the certificate type (e.g. `ISO9001`).
+        certificateTypeVersion:
+          type: string
+          description: |
+            The version of the certificate type itself (e.g. `2015` for
+            ISO 9001:2015). Distinct from the certificate's `version`.
+        certifiedBpn:
+          type: string
+          description: The BPNL of the certified legal entity the certificate is issued on.
+          pattern: "^BPNL[a-zA-Z0-9]{12}$"
+        registrationNumber:
+          type: string
+          description: The certificate's registration number at the issuing body.
+        validFrom:
+          type: string
+          format: date
+          description: |
+            Inclusive start date of the certificate validity period
+            (ISO 8601 full-date, `YYYY-MM-DD`).
+        validUntil:
+          type: string
+          format: date
+          description: |
+            Inclusive end date of the certificate validity period
+            (ISO 8601 full-date, `YYYY-MM-DD`).
+        trustLevel:
+          type: string
+          description: The degree to which the certificate has been validated.
+          enum: [none, low, medium, high, trusted]
+        areaOfApplication:
+          type: string
+          description: |
+            Free-text detail of the areas or application types the certificate
+            is valid for overall. Individual locations MAY narrow this via
+            `Location.areaOfApplication`.
+        enclosedSites:
+          type: array
+          description: |
+            The sites or addresses the certificate applies to. If omitted or
+            empty, the certificate applies to the issuing legal entity as a
+            whole.
+          items:
+            $ref: '#/components/schemas/EnclosedSite'
+        issuer:
+          $ref: '#/components/schemas/CertificateIssuer'
+        validator:
+          $ref: '#/components/schemas/CertificateValidator'
+        documents:
+          type: array
+          description: |
+            Documents associated with this certificate version. Each document is
+            retrieved independently via `GET /documents/{id}`. If omitted or
+            empty, the version has no associated documents.
+          items:
+            $ref: '#/components/schemas/CertificateDocument'
+
+    CertificateAcceptanceStatusEvent:
+      type: object
+      description: |
+        CloudEvents 1.0 envelope carrying a certificate acceptance status
+        payload. The Acceptance-phase outcome is carried in `data.status`.
+      required:
+        - specversion
+        - type
+        - source
+        - id
+        - time
+        - data
+      properties:
+        specversion:
+          type: string
+          enum: ["1.0"]
+        type:
+          type: string
+          enum: [org.catena-x.ccm.CertificateAcceptanceStatus.v1]
+        source:
+          type: string
+          format: uri
+          description: |
+            URI identifying the producing Certificate Consumer. Typically a
+            BPN-scoped URN.
+        subject:
+          type: string
+          description: The BPN of the addressed Certificate Provider.
+        id:
+          type: string
+          description: Unique identifier of this event instance.
+        time:
+          type: string
+          format: date-time
+        datacontenttype:
+          type: string
+          enum: [application/json]
+        dataschema:
+          type: string
+          format: uri
+        data:
+          $ref: '#/components/schemas/CertificateAcceptanceStatus'
+
+    CertificateStatusBase:
+      type: object
+      description: |
+        Common certificate-status base payload. Carries the `exchangeId` (when
+        the event belongs to a Certificate Exchange), the subject `certificateId`,
+        and a `status`. Concrete event payloads derive from this schema and
+        constrain `status` to the values defined for their endpoint.
+      required:
+        - certificateId
+        - status
+      properties:
+        exchangeId:
+          type: string
+          description: |
+            Identifier of the Certificate Exchange the event belongs to. Distinct
+            from the CloudEvent `id`. Present when the event pertains to an
+            exchange; subtypes may require it.
+        certificateId:
+          type: string
+          description: |
+            Unique identifier of the certificate the status applies to.
+        status:
+          type: string
+          description: |
+            The status value. Subtypes constrain the permitted set of values.
+
+    CertificateAcceptanceStatus:
+      description: |
+        Certificate acceptance status payload, derived from
+        `CertificateStatusBase`. Reports on a Certificate Exchange, so
+        `exchangeId` is required.
+      allOf:
+        - $ref: '#/components/schemas/CertificateStatusBase'
+        - type: object
+          required:
+            - exchangeId
+          properties:
+            status:
+              type: string
+              enum: [RETRIEVED, ACCEPTED, REJECTED, ERRORED]
+              description: The acceptance status of the certificate.
+            errors:
+              type: array
+              description: |
+                Error details. MUST NOT be present when `status` is `RETRIEVED`
+                or `ACCEPTED`. MUST be present and non-empty when `status` is
+                `REJECTED` or `ERRORED`.
+              items:
+                $ref: '#/components/schemas/StatusError'
+
+    StatusError:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Human-readable description of the error.
+        specifier:
+          type: string
+          description: |
+            Optional identifier scoping the error to a particular element of
+            the certificate, such as a site BPN. If omitted, the error
+            applies to the certificate as a whole.
+
+    CertificateQuery:
+      type: object
+      description: |
+        Request body for `POST /certificates/search`. All criteria are optional;
+        an empty query returns all accessible certificates. Criteria of different
+        kinds are combined with AND; within a single BPN list the match is
+        any-of.
+      properties:
+        certificateType:
+          type: string
+          description: |
+            Opaque string identifying the certificate type to be matched
+            (for example, `ISO9001`).
+        legalEntityBpns:
+          type: array
+          description: |
+            Filter to certificates issued for these legal entities (matched
+            against `certifiedBpn`).
+          items:
+            type: string
+            pattern: "^BPNL[a-zA-Z0-9]{12}$"
+        siteBpns:
+          type: array
+          description: |
+            Filter to certificates covering these sites (matched against the
+            `enclosedSites`).
+          items:
+            type: string
+            pattern: "^BPNS[a-zA-Z0-9]{12}$"
+        addressBpns:
+          type: array
+          description: |
+            Filter to certificates covering these addresses (matched against
+            the `enclosedSites`).
+          items:
+            type: string
+            pattern: "^BPNA[a-zA-Z0-9]{12}$"
+        from:
+          type: string
+          format: date
+          description: |
+            Inclusive lower bound of the certificate validity range
+            (ISO 8601 full-date). Only certificates whose `validFrom` is on
+            or after this date are returned.
+        to:
+          type: string
+          format: date
+          description: |
+            Inclusive upper bound of the certificate validity range
+            (ISO 8601 full-date). Only certificates whose `validUntil` is on
+            or before this date are returned.
+        limit:
+          type: integer
+          minimum: 1
+          description: |
+            Maximum number of results to return in a single page. If
+            omitted, the Certificate Provider MAY apply a default limit.
+
+    CertificateQueryResponse:
+      type: object
+      description: A single result entry in a certificate query response.
+      required:
+        - certificateId
+        - version
+        - datasetId
+        - certificateType
+        - certifiedBpn
+        - registrationNumber
+        - validFrom
+        - validUntil
+        - trustLevel
+      properties:
+        certificateId:
+          type: string
+          description: |
+            Unique identifier of the certificate, usable in
+            `GET /certificates/{id}`.
+        version:
+          type: integer
+          description: The latest version of the certificate.
+        datasetId:
+          type: string
+          description: |
+            Identifier of the DSP dataset under which the certificate is
+            exposed in the Certificate Provider's catalog, enabling the consumer
+            to locate and negotiate the certificate via the Dataspace Protocol.
+        certificateType:
+          type: string
+        certificateTypeVersion:
+          type: string
+          description: |
+            The version of the certificate type itself (e.g. `2015` for
+            ISO 9001:2015). Distinct from the certificate's `version`.
+        certifiedBpn:
+          type: string
+          description: The BPNL of the certified legal entity the certificate is issued on.
+          pattern: "^BPNL[a-zA-Z0-9]{12}$"
+        registrationNumber:
+          type: string
+          description: The certificate's registration number at the issuing body.
+        validFrom:
+          type: string
+          format: date
+        validUntil:
+          type: string
+          format: date
+        trustLevel:
+          type: string
+          description: The degree to which the certificate has been validated.
+          enum: [none, low, medium, high, trusted]
+        areaOfApplication:
+          type: string
+          description: |
+            Free-text detail of the areas or application types the certificate
+            is valid for.
+        enclosedSiteBpns:
+          type: array
+          items:
+            type: string
+        issuer:
+          $ref: '#/components/schemas/CertificateIssuer'
+        validator:
+          $ref: '#/components/schemas/CertificateValidator'
+        documents:
+          type: array
+          description: |
+            Documents associated with the returned certificate version, each
+            retrieved independently via `GET /documents/{id}`.
+          items:
+            $ref: '#/components/schemas/CertificateDocument'
+
+    Error:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Human-readable error description.
+
+  responses:
+    BadRequest:
+      description: The request was malformed or failed validation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: The request was not authenticated.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Forbidden:
+      description: The caller is not authorized to perform this operation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: The referenced certificate does not exist or is not visible to the caller.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    InternalServerError:
+      description: An unexpected error occurred on the server.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        Bearer token as defined by CX-0000 Section 4 (HTTPS Binding).
+
+security:
+  - bearerAuth: []

--- a/docs/standards/CX-0135-CompanyCertificateManagement/certificate-provider-api-jim.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/certificate-provider-api-jim.yaml
@@ -1,0 +1,825 @@
+openapi: 3.0.3
+info:
+  title: Certificate Provider API
+  description: |
+    HTTP API exposed by a Certificate Provider to accept certificate requests,
+    report request fulfillment status, serve certificate data, accept
+    acceptance status updates, and answer certificate queries, as defined in
+    CX-0135 Section 4.4.
+
+    A certificate is identified by the (`certificateId`, `version`) pair. A
+    consumer-initiated request opens a Certificate Exchange; the Certificate
+    Provider assigns `certificateId` and `version` when it accepts the request.
+
+    All requests MUST use HTTPS (TLS 1.2 or higher). Authorization MUST adhere
+    to CX-0000 (CloudEventsFoundation) Section 4.
+  version: 1.0.0
+
+servers:
+  - url: https://{base}
+    description: Certificate Provider base URL
+    variables:
+      base:
+        default: api.example.com
+        description: Host serving the Certificate Provider API
+
+paths:
+  /certificate-requests:
+    post:
+      summary: Request a certificate
+      description: |
+        Invoked by a Certificate Consumer to request a certificate. A request
+        opens a consumer-initiated Certificate Exchange. On acceptance the
+        Certificate Provider assigns and returns a `certificateId` and
+        `version`, enabling the consumer to poll fulfillment status and later
+        retrieve the certificate.
+      operationId: createCertificateRequest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CertificateRequest'
+            examples:
+              byType:
+                summary: Request a certificate by type and location
+                value:
+                  certificateType: ISO9001
+                  locationBpns:
+                    - BPNS00000003AYRE
+      responses:
+        '202':
+          description: |
+            The request was accepted. The body carries the assigned
+            `certificateId` and `version` and the current fulfillment status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateRequestResponse'
+              examples:
+                acknowledged:
+                  summary: Accepted for asynchronous fulfillment
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: ACKNOWLEDGED
+                fulfilled:
+                  summary: Certificate already available
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: FULFILLED
+                declined:
+                  summary: Request refused
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: DECLINED
+                    errors:
+                      - message: Certificate type not offered for the requested location
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /certificate-requests/{id}:
+    get:
+      summary: Poll the fulfillment status of a request
+      description: |
+        Invoked by a Certificate Consumer to poll the fulfillment status of a
+        previously submitted certificate request. This endpoint reports only the
+        Fulfillment phase; the consumer's acceptance outcome is reported
+        separately via `POST /certificate-acceptance-notifications`.
+
+        Polling is optional: if the Certificate Consumer exposes the Certificate
+        Consumer Notification API, the Certificate Provider MAY instead push
+        these fulfillment status updates to it as a
+        `org.catena-x.ccm.CertificateFulfillmentStatus.v1` event (CX-0135
+        Section 4.3.2). The push and the poll are equivalent and carry the same
+        `exchangeId` and `status`.
+      operationId: getCertificateRequestStatus
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: |
+            The `exchangeId` returned in the response to the certificate
+            request.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current fulfillment status of the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateRequestStatus'
+              examples:
+                acknowledged:
+                  summary: Status ACKNOWLEDGED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: ACKNOWLEDGED
+                fulfilled:
+                  summary: Status FULFILLED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: FULFILLED
+                declined:
+                  summary: Status DECLINED
+                  value:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    version: 1
+                    status: DECLINED
+                    errors:
+                      - message: Certificate type not offered for the requested location
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /certificates/{id}:
+    get:
+      summary: Retrieve certificate metadata
+      description: |
+        Retrieves the metadata of a certificate as `application/json`. The
+        certificate is metadata only; binary documents are not included. Each
+        associated document is listed by reference in the `documents` array and
+        retrieved independently via `GET /documents/{id}`.
+        Returns the latest version by default; a specific version may be
+        requested with the `version` query parameter (e.g. to retrieve the exact
+        version a Certificate Exchange concerns). The provider MUST be able to
+        return any version still referenced by a non-terminal Certificate
+        Exchange.
+      operationId: getCertificate
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The unique identifier of the certificate.
+          schema:
+            type: string
+        - name: version
+          in: query
+          required: false
+          description: |
+            The specific version to retrieve. If omitted, the latest version is
+            returned.
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: |
+            Certificate found. The response is the JSON metadata described by
+            `CertificateMetadata`, including the `documents` array referencing
+            the documents associated with the returned version.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateMetadata'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /documents/{id}:
+    get:
+      summary: Retrieve a certificate document
+      description: |
+        Retrieves a certificate document by its identifier. The response body is
+        the document binary, served directly with the `Content-Type` set to the
+        document's `mediaType` (e.g. `application/pdf`) as advertised in the
+        certificate metadata.
+        A `documentId` is opaque and independent of any certificate version; the
+        same document may be referenced by multiple certificate versions, so no
+        `version` parameter is required.
+      operationId: getDocument
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The opaque, version-independent identifier of the document.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: |
+            Document found. The response body is the document binary, served with
+            the `Content-Type` set to the document's `mediaType`.
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /certificate-acceptance-notifications:
+    post:
+      summary: Submit a certificate acceptance status event
+      description: |
+        Invoked by a Certificate Consumer to report the acceptance status of a
+        certificate. The status is carried in `data.status` and the Certificate
+        Provider dispatches on it. The event is correlated to its Certificate
+        Exchange by the `exchangeId` in `data`. Acceptance MUST reference an
+        existing exchange (opened by a consumer request or a provider
+        notification); merely retrieving a certificate does not establish an
+        exchange. An unknown `exchangeId` is rejected with 404. The body is a
+        single CloudEvent or a batch (JSON array).
+      operationId: postCertificateAcceptanceNotification
+      requestBody:
+        required: true
+        content:
+          application/cloudevents+json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/CertificateAcceptanceStatusEvent'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/CertificateAcceptanceStatusEvent'
+            examples:
+              retrieved:
+                summary: Status RETRIEVED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateAcceptanceStatus.v1
+                  source: urn:bpn:BPNL0000000002CD
+                  subject: BPNL0000000001AB
+                  id: e9f8d7c6-b5a4-9382-7160-5a4b3c2d1e0f
+                  time: "2025-05-04T08:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: RETRIEVED
+              accepted:
+                summary: Status ACCEPTED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateAcceptanceStatus.v1
+                  source: urn:bpn:BPNL0000000002CD
+                  subject: BPNL0000000001AB
+                  id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d
+                  time: "2025-05-04T09:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: ACCEPTED
+              rejected:
+                summary: Status REJECTED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateAcceptanceStatus.v1
+                  source: urn:bpn:BPNL0000000002CD
+                  subject: BPNL0000000001AB
+                  id: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
+                  time: "2025-05-04T09:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: REJECTED
+                    errors:
+                      - message: Certificate has expired
+                      - message: Unexpected data format
+                      - specifier: BPNS000000000002
+                        message: Site BPNS000000000002 has been Rejected
+              errored:
+                summary: Status ERRORED
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateAcceptanceStatus.v1
+                  source: urn:bpn:BPNL0000000002CD
+                  subject: BPNL0000000001AB
+                  id: c8d7e6f5-a4b3-2109-8765-432109fedcba
+                  time: "2025-05-04T08:30:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-acceptance-status.json
+                  data:
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: ERRORED
+                    errors:
+                      - message: Certificate document is malformed and cannot be validated
+      responses:
+        '204':
+          description: Acceptance status accepted; response body is empty.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /certificates/search:
+    post:
+      summary: Search certificates
+      description: |
+        Returns certificates matching the supplied criteria. Results MAY be
+        paginated; when paginated, navigation URLs are provided in the `Link`
+        response header in accordance with RFC 8288 (Web Linking). Only the
+        `next` and `prev` link relations are guaranteed; `first` and `last`
+        MAY also be returned. To retrieve a subsequent page, the client
+        re-issues a `POST` with the same request body against the URL
+        provided in the corresponding `Link` value.
+      operationId: queryCertificates
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CertificateQuery'
+            examples:
+              byType:
+                summary: Query by certificate type and validity window
+                value:
+                  certificateType: ISO9001
+                  from: "2023-01-25"
+                  to: "2026-01-24"
+                  limit: 50
+      responses:
+        '200':
+          description: |
+            Matching certificates. When the result set is paginated, the
+            response includes a `Link` header per RFC 8288.
+          headers:
+            Link:
+              description: |
+                Web Linking pagination header (RFC 8288). Contains URLs for
+                the `next` and/or `prev` pages. Omitted when the response is
+                not paginated.
+              schema:
+                type: string
+              example: >-
+                <https://provider.example.com/certificates/search?cursor=eyJvZmZzZXQiOjUwfQ>; rel="next",
+                <https://provider.example.com/certificates/search?cursor=eyJvZmZzZXQiOjB9>; rel="prev"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CertificateQueryResponse'
+              examples:
+                page:
+                  summary: A single page of results
+                  value:
+                    - certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                      version: 1
+                      datasetId: dataset-ccm-cert-abc123
+                      certificateType: ISO9001
+                      validFrom: "2023-01-25"
+                      validUntil: "2026-01-24"
+                      locationBpns:
+                        - BPNS00000003AYRE
+                        - BPNA000000000001
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  schemas:
+    CertificateRequest:
+      type: object
+      description: Request body for `POST /certificate-requests`.
+      required:
+        - certificateType
+      properties:
+        certificateType:
+          type: string
+          description: |
+            Opaque string identifying the certificate type to be requested
+            (for example, `ISO9001`).
+        locationBpns:
+          type: array
+          description: |
+            BPNs of the sites or addresses the request applies to. If omitted,
+            the request applies to the legal entity.
+          items:
+            type: string
+
+    CertificateRequestResponse:
+      type: object
+      description: |
+        Response to an accepted certificate request. Carries the assigned
+        exchange and certificate identity and the initial fulfillment status.
+      required:
+        - exchangeId
+        - certificateId
+        - version
+        - status
+      properties:
+        exchangeId:
+          type: string
+          description: |
+            Identifier assigned to the opened Certificate Exchange. Used to poll
+            fulfillment status via `GET /certificate-requests/{id}`.
+        certificateId:
+          type: string
+          description: |
+            Identifier assigned to the requested certificate. Used to retrieve
+            the certificate via `GET /certificates/{id}`.
+        version:
+          type: integer
+          description: Version assigned to the requested certificate.
+        status:
+          type: string
+          enum: [ACKNOWLEDGED, CERTIFICATION_REQUESTED, FULFILLED, DECLINED]
+          description: The fulfillment status of the request.
+        errors:
+          type: array
+          description: |
+            Error details. MUST be present and non-empty when `status` is
+            `DECLINED`.
+          items:
+            $ref: '#/components/schemas/StatusError'
+
+    CertificateRequestStatus:
+      type: object
+      description: |
+        Current fulfillment status of a certificate request.
+      required:
+        - exchangeId
+        - certificateId
+        - version
+        - status
+      properties:
+        exchangeId:
+          type: string
+          description: |
+            Identifier of the Certificate Exchange. Matches the `{id}` path
+            parameter of the request.
+        certificateId:
+          type: string
+          description: Unique identifier of the requested certificate.
+        version:
+          type: integer
+          description: The version of the requested certificate.
+        status:
+          type: string
+          enum: [ACKNOWLEDGED, CERTIFICATION_REQUESTED, FULFILLED, DECLINED, FAILED]
+          description: The current fulfillment status.
+        errors:
+          type: array
+          description: |
+            Error details. MUST be present and non-empty when `status` is
+            `DECLINED` or `FAILED`.
+          items:
+            $ref: '#/components/schemas/StatusError'
+
+    CertificateDocument:
+      type: object
+      description: |
+        A reference to a document associated with a certificate version. The
+        binary is retrieved separately via `GET /documents/{id}`.
+      required:
+        - documentId
+        - mediaType
+      properties:
+        documentId:
+          type: string
+          description: |
+            Opaque, version-independent identifier of the document, used to
+            retrieve it via `GET /documents/{id}`.
+          examples:
+            - "doc-3fa85f64-5717-4562-b3fc-2c963f66afa6"
+        mediaType:
+          type: string
+          description: IANA media type of the document binary.
+          examples:
+            - "application/pdf"
+            - "image/png"
+
+    CertificateMetadata:
+      type: object
+      description: JSON metadata accompanying a retrieved certificate.
+      required:
+        - certificateId
+        - version
+        - certificateType
+        - validFrom
+        - validUntil
+      properties:
+        certificateId:
+          type: string
+          description: |
+            Unique identifier of the certificate. Matches the `{id}` path
+            parameter of the request.
+        version:
+          type: integer
+          description: |
+            The version returned — the version requested via the `version` query
+            parameter, or the latest version if none was specified.
+        certificateType:
+          type: string
+          description: Opaque string identifying the certificate type (e.g. `ISO9001`).
+        validFrom:
+          type: string
+          format: date
+          description: |
+            Inclusive start date of the certificate validity period
+            (ISO 8601 full-date, `YYYY-MM-DD`).
+        validUntil:
+          type: string
+          format: date
+          description: |
+            Inclusive end date of the certificate validity period
+            (ISO 8601 full-date, `YYYY-MM-DD`).
+        locationBpns:
+          type: array
+          description: |
+            BPNs of the sites or addresses the certificate applies to. If
+            omitted, the certificate applies to the issuing legal entity as a
+            whole.
+          items:
+            type: string
+        documents:
+          type: array
+          description: |
+            Documents associated with this certificate version. Each document is
+            retrieved independently via `GET /documents/{id}`. If omitted or
+            empty, the version has no associated documents.
+          items:
+            $ref: '#/components/schemas/CertificateDocument'
+
+    CertificateAcceptanceStatusEvent:
+      type: object
+      description: |
+        CloudEvents 1.0 envelope carrying a certificate acceptance status
+        payload. The Acceptance-phase outcome is carried in `data.status`.
+      required:
+        - specversion
+        - type
+        - source
+        - id
+        - time
+        - data
+      properties:
+        specversion:
+          type: string
+          enum: ["1.0"]
+        type:
+          type: string
+          enum: [org.catena-x.ccm.CertificateAcceptanceStatus.v1]
+        source:
+          type: string
+          format: uri
+          description: |
+            URI identifying the producing Certificate Consumer. Typically a
+            BPN-scoped URN.
+        subject:
+          type: string
+          description: The BPN of the addressed Certificate Provider.
+        id:
+          type: string
+          description: Unique identifier of this event instance.
+        time:
+          type: string
+          format: date-time
+        datacontenttype:
+          type: string
+          enum: [application/json]
+        dataschema:
+          type: string
+          format: uri
+        data:
+          $ref: '#/components/schemas/CertificateAcceptanceStatus'
+
+    CertificateStatusBase:
+      type: object
+      description: |
+        Common certificate-status base payload. Carries the `exchangeId` (when
+        the event belongs to a Certificate Exchange), the subject `certificateId`,
+        and a `status`. Concrete event payloads derive from this schema and
+        constrain `status` to the values defined for their endpoint.
+      required:
+        - certificateId
+        - status
+      properties:
+        exchangeId:
+          type: string
+          description: |
+            Identifier of the Certificate Exchange the event belongs to. Distinct
+            from the CloudEvent `id`. Present when the event pertains to an
+            exchange; subtypes may require it.
+        certificateId:
+          type: string
+          description: |
+            Unique identifier of the certificate the status applies to.
+        status:
+          type: string
+          description: |
+            The status value. Subtypes constrain the permitted set of values.
+
+    CertificateAcceptanceStatus:
+      description: |
+        Certificate acceptance status payload, derived from
+        `CertificateStatusBase`. Reports on a Certificate Exchange, so
+        `exchangeId` is required.
+      allOf:
+        - $ref: '#/components/schemas/CertificateStatusBase'
+        - type: object
+          required:
+            - exchangeId
+          properties:
+            status:
+              type: string
+              enum: [RETRIEVED, ACCEPTED, REJECTED, ERRORED]
+              description: The acceptance status of the certificate.
+            errors:
+              type: array
+              description: |
+                Error details. MUST NOT be present when `status` is `RETRIEVED`
+                or `ACCEPTED`. MUST be present and non-empty when `status` is
+                `REJECTED` or `ERRORED`.
+              items:
+                $ref: '#/components/schemas/StatusError'
+
+    StatusError:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Human-readable description of the error.
+        specifier:
+          type: string
+          description: |
+            Optional identifier scoping the error to a particular element of
+            the certificate, such as a site BPN. If omitted, the error
+            applies to the certificate as a whole.
+
+    CertificateQuery:
+      type: object
+      description: Request body for `POST /certificates/search`.
+      required:
+        - certificateType
+      properties:
+        certificateType:
+          type: string
+          description: |
+            Opaque string identifying the certificate type to be matched
+            (for example, `ISO9001`).
+        from:
+          type: string
+          format: date
+          description: |
+            Inclusive lower bound of the certificate validity range
+            (ISO 8601 full-date). Only certificates whose `validFrom` is on
+            or after this date are returned.
+        to:
+          type: string
+          format: date
+          description: |
+            Inclusive upper bound of the certificate validity range
+            (ISO 8601 full-date). Only certificates whose `validUntil` is on
+            or before this date are returned.
+        limit:
+          type: integer
+          minimum: 1
+          description: |
+            Maximum number of results to return in a single page. If
+            omitted, the Certificate Provider MAY apply a default limit.
+
+    CertificateQueryResponse:
+      type: object
+      description: A single result entry in a certificate query response.
+      required:
+        - certificateId
+        - version
+        - datasetId
+        - certificateType
+        - validFrom
+        - validUntil
+      properties:
+        certificateId:
+          type: string
+          description: |
+            Unique identifier of the certificate, usable in
+            `GET /certificates/{id}`.
+        version:
+          type: integer
+          description: The latest version of the certificate.
+        datasetId:
+          type: string
+          description: |
+            Identifier of the DSP dataset under which the certificate is
+            exposed in the Certificate Provider's catalog.
+        certificateType:
+          type: string
+        validFrom:
+          type: string
+          format: date
+        validUntil:
+          type: string
+          format: date
+        locationBpns:
+          type: array
+          items:
+            type: string
+        documents:
+          type: array
+          description: |
+            Documents associated with the returned certificate version, each
+            retrieved independently via `GET /documents/{id}`.
+          items:
+            $ref: '#/components/schemas/CertificateDocument'
+
+    Error:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Human-readable error description.
+
+  responses:
+    BadRequest:
+      description: The request was malformed or failed validation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: The request was not authenticated.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Forbidden:
+      description: The caller is not authorized to perform this operation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: The referenced certificate does not exist or is not visible to the caller.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    InternalServerError:
+      description: An unexpected error occurred on the server.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        Bearer token as defined by CX-0000 Section 4 (HTTPS Binding).
+
+security:
+  - bearerAuth: []


### PR DESCRIPTION
This is a first pass at merging the CloudEvents version into the current edits. Some notes:

- There is a document explaining merged items, CX-0135-CompanyCertificateManagement-merge-notes.md. Please look at that first.
- I kept CX-0000 separate as that will eventually be a base CloudEvents spec for all use cases
- I added the original `jim` documents for reference. They can be deleted later.
- The combined documents have the suffix `-combined`.
- The Open API specs are divided into provider and consumer. We can merge them if people think that is better.
- When we are satisfied with the merge, we can rename the `-combined` documents to the original naming scheme.
- I included Stefanie's comments to my version prior to merging here.
