### PR TITLE
feat: revise spec to align with OpenAPI definitions; align text for consistency, demote non-specification foreign text to references rather than normative statements

### DIFF
--- a/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/CX-0135-CompanyCertificateManagement.md
@@ -10,8 +10,8 @@ tags:
 In the world of business, company certificates are often mandatory for conducting transactions between two companies.
 However, the process of provisioning, maintaining, and validating these certificates can be a major challenge. For
 example, if a company has 100 customers, it may need to provide its company certificates in 100 different ways and
-maintain them at 100 different points. To address this, this standard defines a standardized but generic data model 
-and a wire protocol for company certificates. 
+maintain them at 100 different points. To address this, this standard defines a standardized but generic data model and
+a wire protocol for company certificates.
 
 ## 1 Introduction
 
@@ -19,8 +19,8 @@ and a wire protocol for company certificates.
 
 > *This section is non-normative*
 
-This specification builds upon [CX-0151](#cx-0151) and [CX-0002](#cx-0002) to define a Company Certificate 
-Management (CCM) wire protocol for exchanging company certificate data between Catena-X participants.
+This specification builds upon [CX-0151](#cx-0151) to define a Company Certificate Management (CCM) wire protocol for
+exchanging company certificate data between Catena-X participants.
 
 The following company certificate business requirements are supported in this release:
 
@@ -36,7 +36,7 @@ This standard is relevant to the following parties:
 - Business Application Provider
 - Enablement Service Provider
 
-It especially applies to business application providers who aim to offer a solution for managing and exchanging company
+It especially applies to Business Application Providers who aim to offer a solution for managing and exchanging company
 certificates and returning them to customers, and to Data Providers and Consumers who manage and exchange certificates,
 e.g., through such a business application.
 
@@ -53,16 +53,21 @@ The keywords **MAY**, **MUST**, **MUST NOT**, **OPTIONAL**, **RECOMMENDED**, **R
 NOT** in this document are to be interpreted as described in BCP 14 [RFC2119](#rfc2119) [RFC8174](#rfc8174) when, and
 only when they appear in all capitals, as shown here.
 
-- A participant **MAY** support any of the APIs (based on their need; more explicitly, a consumer role without
-  support of the Certificate Consumer API is valid):
-  - Certificate Consumer API (see [Section 3.1](#31-certificate-consumer-api))
-  - Certificate Provider API (see [Section 3.2](#32-certificate-provider-api))
+- A participant **MAY** support any of the APIs (based on their need; more explicitly, a Consumer role without support
+  of the Certificate Consumer API is valid):
+    - Certificate Consumer API (see [Section 3.2](#32-certificate-consumer-api))
+    - Certificate Provider API (see [Section 3.3](#33-certificate-provider-api))
 - Business Application Provides **MUST** support both, the Certificate Provider API and the Certificate Consumer API.
-- Based on the previous requirements, the participant **MUST** be compliant with all normative requirements defined 
-  in the respective sections of this standard. Especially the state machines, APIs and data model. Even a consumer
-  without a Certificate Consumer API **MUST** proof to be compliant with 
-  [Section 2](#2-relevant-parts-of-the-standard-for-specific-use-cases) and [Section 5](#5-certificate-data-model) 
+- Based on the previous requirements, the participant **MUST** be compliant with all normative requirements defined in
+  the respective sections of this standard. Especially the state machines, APIs and data model. Even a Consumer without
+  a Certificate Consumer API **MUST** proof to be compliant with
+  [Section 2](#2-relevant-parts-of-the-standard-for-specific-use-cases) and [Section 4](#4-aspect-models)
   of this standard.
+
+> **Note:** three independent version numbers appear in this standard and are **not** expected to match. The document
+> version (**v3.0.0**), the certificate aspect-model version
+> ([io.catenax.business_partner_certificate](#sldt-business-partner-certificate-400) **4.0.0**), and the API/asset
+> version (`cx-common:version` **3.0** and the OpenAPI `info.version` `3.0.0`) are independent.
 
 ## 2 RELEVANT PARTS OF THE STANDARD FOR SPECIFIC USE CASES
 
@@ -97,14 +102,13 @@ An exchange concerns a specific certificate, a (`certificateId`, `revision`) pai
 
 A `Certificate Exchange` may be opened by the Certificate Consumer or Certificate Provider:
 
-- **Consumer-Initiated:** the Certificate Consumer opens the exchange by requesting a certificate. The
-  Certificate Provider assigns the `exchangeId` (together with the `certificateId` and `revision`) and returns them in
-  the response. Every request opens an exchange — including one the provider declines synchronously, which could open an
-  exchange that terminates immediately at `DECLINED`; the identifiers are still returned so the outcome remains
-  correlatable.
+- **Consumer-Initiated:** the Certificate Consumer opens the exchange by requesting a certificate. The Certificate
+  Provider assigns the `exchangeId` (together with the `certificateId` and `revision`) and returns them in the response.
+  Every request opens an exchange — including one the Provider declines synchronously, which could open an exchange that
+  terminates immediately at `DECLINED`; the identifiers are still returned so the outcome remains correlatable.
 - **Provider-Initiated:** the Certificate Provider opens the exchange when a certificate is already available (e.g.,
-  freshly created by a user of the certificate application without a previous consumer-initiated request), 
-  assigning an `exchangeId` and carrying it — with the `certificateId` and `revision` — in the notification.
+  freshly created by a user of the certificate application without a previous consumer-initiated request), assigning an
+  `exchangeId` and carrying it — with the `certificateId` and `revision` — in the notification.
 
 **Idempotency.** Each `Certificate Exchange` has a unique `exchangeId`. A message that repeats an `exchangeId` refers to
 the same exchange rather than opening a new one. Multiple exchanges **MAY** concern the same certificate and
@@ -127,8 +131,8 @@ A `Certificate Exchange` progresses through two sequential phases, each owned by
 
 The phases never overlap: the `Acceptance` phase begins only once `Fulfillment` has made the certificate available.
 Provider-owned and Consumer-owned states use deliberately disjoint vocabulary, so the owner of a state is unambiguous.
-Each phase can end in a negative decision or a business error: `DECLINED`/`REJECTED` are decisions (the provider
-declines the request, or the consumer does not accept the certificate), while `FAILED`/`ERRORED` indicate a business
+Each phase can end in a negative decision or a business error: `DECLINED`/`REJECTED` are decisions (the Provider
+declines the request, or the Consumer does not accept the certificate), while `FAILED`/`ERRORED` indicate a business
 error such as an invalid certificate. These error states represent business-level problems only; technical and transport
 failures (for example, connectivity errors or timeouts) are not modeled as `Certificate Exchange` states and are handled
 at the transport layer.
@@ -192,43 +196,43 @@ stateDiagram-v2
 
 | State                     | Correlation        | Phase       | Owner    | Terminal | Description                                                                                                      |
 |---------------------------|--------------------|-------------|----------|----------|------------------------------------------------------------------------------------------------------------------|
-| `REQUESTED`               | Consumer-Initiated | Fulfillment | Provider | No       | The exchange was opened by the consumer; the provider has not yet acted.                                         |
-| `ACKNOWLEDGED`            | Consumer-Initiated | Fulfillment | Provider | No       | The provider accepted the request and began preparing the certificate.                                           |
-| `CERTIFICATION_REQUESTED` | Consumer-Initiated | Fulfillment | Provider | No       | The provider submitted the request to an external certification authority and is awaiting issuance. *(Optional)* |
-| `FULFILLED`               | Consumer-Initiated | Fulfillment | Provider | No       | The certificate is prepared and available for retrieval and the consumer was notified. Hand-off point.           |
-| `DECLINED`                | Consumer-Initiated | Fulfillment | Provider | Yes      | The provider declined the request (a business decision; e.g. the certificate type is not offered).               |
-| `FAILED`                  | Consumer-Initiated | Fulfillment | Provider | Yes      | The provider could not produce a valid certificate (a business error; e.g. the certificate is invalid).          |
-| `RETRIEVED`               | -                  | Acceptance  | Consumer | No       | The consumer fetched the certificate and is processing it. *(Optional — see the note below.)*                    |
-| `ACCEPTED`                | -                  | Acceptance  | Consumer | Yes      | The consumer accepted the certificate.                                                                           |
-| `REJECTED`                | -                  | Acceptance  | Consumer | Yes      | The consumer did not accept the certificate content (a business decision).                                       |
-| `ERRORED`                 | -                  | Acceptance  | Consumer | Yes      | The consumer found the certificate to be in error (a business error; e.g. the certificate is invalid).           |
+| `REQUESTED`               | Consumer-Initiated | Fulfillment | Provider | No       | The exchange was opened by the Consumer; the Provider has not yet acted.                                         |
+| `ACKNOWLEDGED`            | Consumer-Initiated | Fulfillment | Provider | No       | The Provider accepted the request and began preparing the certificate.                                           |
+| `CERTIFICATION_REQUESTED` | Consumer-Initiated | Fulfillment | Provider | No       | The Provider submitted the request to an external certification authority and is awaiting issuance. *(Optional)* |
+| `FULFILLED`               | Consumer-Initiated | Fulfillment | Provider | No       | The certificate is prepared and available for retrieval and the Consumer was notified. Hand-off point.           |
+| `DECLINED`                | Consumer-Initiated | Fulfillment | Provider | Yes      | The Provider declined the request (a business decision; e.g. the certificate type is not offered).               |
+| `FAILED`                  | Consumer-Initiated | Fulfillment | Provider | Yes      | The Provider could not produce a valid certificate (a business error; e.g. the certificate is invalid).          |
+| `RETRIEVED`               | -                  | Acceptance  | Consumer | No       | The Consumer fetched the certificate and is processing it. *(Optional — see the note below.)*                    |
+| `ACCEPTED`                | -                  | Acceptance  | Consumer | Yes      | The Consumer accepted the certificate.                                                                           |
+| `REJECTED`                | -                  | Acceptance  | Consumer | Yes      | The Consumer did not accept the certificate content (a business decision).                                       |
+| `ERRORED`                 | -                  | Acceptance  | Consumer | Yes      | The Consumer found the certificate to be in error (a business error; e.g. the certificate is invalid).           |
 
 ##### 2.1.3.1 Consumer-Initiated
 
 `REQUESTED` is instantaneous and internal to the Certificate Provider; it is never reported on the wire. The first
 Fulfillment status a Certificate Consumer observes is the one carried in the request response (see
-[Section 4.4.1](#441-certificate-request)), which is `ACKNOWLEDGED` or a later state. A provider that can satisfy a
-request without intermediate steps **MAY** report a later Fulfillment state directly—for example `FULFILLED` when the
+[Section 3.3.1](#331-certificate-request)), which is `ACKNOWLEDGED` or a later state. A Provider that can satisfy a
+request without intermediate steps **MAY** report a later Fulfillment state directly — for example `FULFILLED` when the
 certificate is already held, or `CERTIFICATION_REQUESTED` when the request is immediately forwarded to an external
-authority—having passed through the earlier states instantly in an automated fashion. A reported `status` therefore 
+authority — having passed through the earlier states instantly in an automated fashion. A reported `status` therefore
 reflects the exchange's current state, not necessarily a single transition from the one before it.
 
 ##### 2.1.3.2 Provider-Initiated
 
-A provider-initiated exchange enters the lifecycle at `FULFILLED` (with potential internal states beforehand when a user 
-creates a certificate). There is no request, so `REQUESTED`, `ACKNOWLEDGED` and `CERTIFICATION_REQUESTED` are never 
+A provider-initiated exchange enters the lifecycle at `FULFILLED` (with potential internal states beforehand when a user
+creates a certificate). There is no request, so `REQUESTED`, `ACKNOWLEDGED` and `CERTIFICATION_REQUESTED` are never
 visited.
 
 ##### 2.1.3.3 Feedback
 
-Any feedback is optional. 
-`RETRIEVED` is a non-terminal acknowledgment that the consumer has fetched the certificate and is
-evaluating it; the consumer **MAY** report it as a delivery receipt but is not required to. 
-An exchange therefore reaches a terminal acceptance state either by way of `RETRIEVED` 
-(`FULFILLED → RETRIEVED → {ACCEPTED, REJECTED, ERRORED}`) 
-or directly from `FULFILLED` (`FULFILLED → {ACCEPTED, REJECTED, ERRORED}`). 
-The terminal acceptance verdicts remain consumer-owned in both cases. If the consumer never provides any feedback, the
-terminal state is never reached for that exchange; it remains in `FULFILLED` indefinitely.
+Any feedback is optional.
+`RETRIEVED` is a non-terminal acknowledgment that the Consumer has fetched the certificate and is evaluating it; the
+Consumer **MAY** report it as a delivery receipt but is not required to. An exchange therefore reaches a terminal
+acceptance state either by way of `RETRIEVED`
+(`FULFILLED → RETRIEVED → {ACCEPTED, REJECTED, ERRORED}`)
+or directly from `FULFILLED` (`FULFILLED → {ACCEPTED, REJECTED, ERRORED}`). The terminal acceptance verdicts remain
+consumer-owned in both cases. If the Consumer never provides any feedback, the terminal state is never reached for that
+exchange; it remains in `FULFILLED` indefinitely.
 
 #### 2.1.4 Terminal States and Immutability
 
@@ -239,9 +243,9 @@ A `Certificate Exchange` is single-shot. The five terminal states — `DECLINED`
 
 A `Certificate Exchange` governs the *delivery* of a certificate, not the certificate itself. Modifications, updates,
 and revocations of a certificate are changes to the certificate artifact and are **not** transitions of a
-`Certificate Exchange`. In particular, a change to a certificate that has already been delivered does not reopen or
+`Certificate Exchange.` In particular, a change to a certificate that has already been delivered does not reopen or
 alter the (possibly terminal) exchange that delivered it. A modification revises the certificate in place under the same
-`certificateId` and does not open a new `Certificate Exchange`. The certificate's own lifecycle is described in
+`certificateId` and does not open a new `Certificate Exchange.` The certificate's own lifecycle is described in
 [Section 2.2](#22-certificate-lifecycle).
 
 ### 2.2 Certificate Lifecycle
@@ -252,26 +256,26 @@ long-lived: it may be published, revised, and eventually withdrawn.
 
 #### 2.2.1 Identity and Versioning
 
-A certificate is identified by a **`certificateId`** that is stable for the life of the certificate. 
-A modification does not create a new identifier; instead, the certificate is versioned by a **`revision`** counter:
+A certificate is identified by a **`certificateId`** that is stable for the life of the certificate. A modification does
+not create a new identifier; instead, the certificate is versioned by a **`revision`** counter:
 
 - `CREATED` makes the first `revision` of the certificate available for retrieval.
 - Each `MODIFIED` publishes a new `revision` under the same `certificateId`, superseding the previous one. The latest
   `revision` is authoritative.
-- A certificate is therefore identified by the pair (`certificateId`, `revision`). 
-  A `Certificate Exchange` delivers one specific `revision`.
+- A certificate is therefore identified by the pair (`certificateId`, `revision`). A `Certificate Exchange` delivers one
+  specific `revision`.
 
 The `certificateId` and the initial `revision` number may be assigned before the certificate is published. When a
-Certificate Provider accepts a consumer's request and produces the certificate only later (see
+Certificate Provider accepts a Consumer's request and produces the certificate only later (see
 [Section 2.1.1](#211-identity-and-correlation)), the identifier is allocated at acceptance so that an in-progress
 `Certificate Exchange` can reference its certificate. Publication (`CREATED`) then occurs when the certificate becomes
 available.
 
-A certificate covers a **fixed set of locations** — the sites (BPNS) and addresses (BPNA) it applies to. On the full
-certificate record these are carried as structured `enclosedSites` (each with an optional per-location area of 
-application; see [Section 4.4.3](#443-certificate-retrieval)); lighter projections such as query results and lifecycle 
-events carry only the bare BPNs as `enclosedSiteBpns`. The location set is a static property of the certificate; 
-a certificate that would cover a different set of locations is a distinct certificate.
+A certificate covers a **fixed set of locations** — the legal entity (BPNL), sites (BPNS), and addresses (BPNA) it
+applies to. On the certificate record these are carried as the structured `certifiedLocations` array (each entry
+identifying a location and its role, with an optional per-location area of application; see
+[Section 4.2.4](#424-certified-locations)). The location set is a static property of the certificate; a certificate that
+would cover a different set of locations is a distinct certificate.
 
 #### 2.2.2 State Machine (Certificate Lifecycle)
 
@@ -294,7 +298,7 @@ stateDiagram-v2
 |-------------|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | `CREATED`   | No       | The certificate was first published under a new `certificateId`, establishing its initial version (`revision` 0).           |
 | `MODIFIED`  | No       | A new `revision` of the certificate was published under the same `certificateId`; the `revision` is incremented. May recur. |
-| `WITHDRAWN` | Yes      | The provider withdrew (removed) the certificate; it is no longer available. Terminal.                                       |
+| `WITHDRAWN` | Yes      | The Provider withdrew (removed) the certificate; it is no longer available. Terminal.                                       |
 
 #### 2.2.3 Validity as a Separate Dimension
 
@@ -310,187 +314,333 @@ expired.
 
 > *This section is non-normative*
 
-Of the publication events, only `CREATED` MAY open a new `Certificate Exchange`—pushed by the provider, or discovered
-and requested by the consumer—to deliver the certificate. `MODIFIED` and `WITHDRAWN` do not open an exchange: a
+Of the publication events, only `CREATED` MAY open a new `Certificate Exchange` to deliver the certificate — whether
+pushed by the Provider or discovered and requested by the Consumer. `MODIFIED` and `WITHDRAWN` do not open an exchange: a
 modification revises the certificate in place under the same `certificateId` without initiating a new delivery, and a
 withdrawal ends the certificate's availability. Consistent with
 [Section 2.1.5](#215-relationship-to-the-certificate-lifecycle), a lifecycle transition never alters an existing
-`Certificate Exchange`. These transitions are communicated to Certificate Consumers as certificate lifecycle events (see
-[Section 3.3.1](#311-certificate-lifecycle-events)).
+`Certificate Exchange.` These transitions are communicated to Certificate Consumers as certificate lifecycle events (see
+[Section 3.2.1](#321-certificate-lifecycle-events)).
 
 ## 3 APPLICATION PROGRAMMING INTERFACES
 
 > *This section is normative*
 
 The API specification is separated in two parts, one for the Certificate Provider and one for the Certificate Consumer.
-Of course a network participant is not limited to either of those roles; for example, a participant could be a 
-Certificate Consumer in one interaction and a Certificate Provider in another. This is based on the participant's needs.
+A network participant is not limited to either of those roles; for example, a participant could be a Certificate
+Consumer in one interaction and a Certificate Provider in another.
 
-This section introduces the certificate management notification API which is based on the following OpenAPI 
+Which APIs a participant exposes depends on its capabilities:
+
+| To…                                                             | Certificate Provider API ([Section 3.3](#33-certificate-provider-api)) | Certificate Consumer API ([Section 3.2](#32-certificate-consumer-api))      |
+|-----------------------------------------------------------------|------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| offer certificates to other participants                        | **MUST** expose                                                        | —                                                                           |
+| receive lifecycle notifications and provide acceptance feedback | —                                                                      | **MUST** expose (register `…ConsumerApi` or `…ConsumerEmbeddedDocumentApi`) |
+| act as a Business Application Provider                          | **MUST** expose                                                        | **MUST** expose                                                             |
+
+Requesting and retrieving certificates from a Provider requires no exposed API — a Certificate Consumer calls the
+Certificate Provider API directly.
+
+This section introduces the certificate management notification API which is based on the following OpenAPI
 specifications which **MUST** be adhered to:
+
 - [Certificate Consumer API](assets/certificate-consumer-api.yaml)
 - [Certificate Provider API](assets/certificate-provider-api.yaml)
 
-The OpenAPI specification **MUST** be used as the baseline, the following subsections add additional normative 
-requirements and clarifications. Each supported API **MUST** be discoverable and made be accessible
-via a [DSP Catalog](#dsp-catalog).
+The OpenAPI specification **MUST** be used as the baseline, the following subsections add additional normative
+requirements and clarifications. Each supported API **MUST** be discoverable and made accessible via
+a [DSP Catalog](#dsp-catalog).
 
 A dataspace participant that chooses to implement an API **MUST**
-- offer an asset to expose the API for Certificate Provider in the connector catalog.
+
+- offer an asset to expose the API for Certificate Provider in the DSP catalog.
 - reference the name of the certificate management API `cx-taxo:CCMAPI` for the property
-  [[type]](http://purl.org/dc/terms/type).
+  [[type]](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#type).
 
 Overview of possible API assets defined in this version of the standard:
 
-| **Type**       | **Subject**                                     | **Version** | **Description**                                                                                                                                                                                                                            |
-|----------------|-------------------------------------------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| cx-taxo:CCMAPI | cx-taxo:CompanyCertificateManagementConsumerApi | 1.0         | Offers *Certificate Consumer API* according to [Section 3.1](#31-certificate-consumer-api) for receiving notifications on certificate lifecycle events and providing feedback on the status of provided certificates.                      |
-| cx-taxo:CCMAPI | cx-taxo:CompanyCertificateManagementProviderApi | 1.0         | Offers *Certificate Provider API* according to [Section 3.2](#32-certificate-provider-api) for requesting certificates, retrieving certificates, providing feedback on the status of certificate requests, and searching for certificates. |
+| **Type**       | **Subject**                                                     | **Version** | **Description**                                                                                                                                                                                                                                                                                        |
+|----------------|-----------------------------------------------------------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| cx-taxo:CCMAPI | cx-taxo:CompanyCertificateManagementConsumerApi                 | 3.0         | Offers *Certificate Consumer API* according to [Section 3.2](#32-certificate-consumer-api) for receiving notifications on certificate lifecycle events and providing feedback on the status of provided certificates.                                                                                  |
+| cx-taxo:CCMAPI | cx-taxo:CompanyCertificateManagementConsumerEmbeddedDocumentApi | 3.0         | Variant of the *Certificate Consumer API* that additionally receives certificate documents embedded inline in `CREATED`/`MODIFIED` lifecycle notifications (see [Section 3.2.1](#321-certificate-lifecycle-events)). A Certificate Consumer registers either this subject or `…ConsumerApi`, not both. |
+| cx-taxo:CCMAPI | cx-taxo:CompanyCertificateManagementProviderApi                 | 3.0         | Offers *Certificate Provider API* according to [Section 3.3](#33-certificate-provider-api) for requesting certificates, retrieving certificates, providing feedback on the status of certificate requests, and searching for certificates.                                                             |
 
-There **MUST** only be one unique asset per API (subject and version) across all connectors of one BPNL.
+There **MUST** only be one unique asset per API (subject and version) for a participant.
 ___
 *Example*: it is possible to have these assets available next to one-another:
 
-- ```{ "dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementConsumerApi" }, "cx-common:version": "1.0" }```,
-- ```{ "dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementProviderApi" }, "cx-common:version": "1.0" }```,
-- ```{ "dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementNotificationApi" }, "cx-common:version": "3.0" }```
+- ```{ "dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementConsumerApi" }, "cx-common:version": "3.0" }```,
+- ```{ "dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementProviderApi" }, "cx-common:version": "3.0" }```,
+- ```{ "dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementProviderApi" }, "cx-common:version": "4.0" }```
 
-since they either differ in the value of the version or the subject.
-But it would not be possible to have two of the same subject and the same version.
+since they either differ in the value of the version or the subject. But it would not be possible to have two of the
+same subject and the same version.
 
 *Example that is not allowed:*
 
-- ```{"dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementConsumerApi" }, "cx-common:version": "1.0" }```,
-- ```{"dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementConsumerApi" }, "cx-common:version": "1.0" }```
+- ```{"dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementConsumerApi" }, "cx-common:version": "3.0" }```,
+- ```{"dct:subject": { "@id": "cx-taxo:CompanyCertificateManagementConsumerApi" }, "cx-common:version": "3.0" }```
 
-It doesn't matter if the assets are offered in one or in different connectors, as long as they belong to the same BPNL 
-this is not allowed, they **MUST** be unique.
+The two assets above are not allowed, because they share both the same subject and the same version.
 ___
 
-### 3.1 Certificate Consumer API
+### 3.1 Security and Authorization
+
+> *This section is normative*
+
+**Transport.** All endpoints defined in this standard **MUST** be exposed over HTTPS (HTTP over TLS 1.2 or higher).
+
+**Authorization.** Access to every CCM API and to certificate data is mediated by the Dataspace Protocol: a caller
+**MUST** have negotiated a contract for the relevant asset and **MUST** present the resulting access token (token
+handling as defined in [CX-0000](#cx-0000)). Use of the data is bound by the usage policy in
+[Section 3.5](#35-usage-policy), including the `cx.ccm.base:1` usage purpose.
+
+**Sender identity.** Every CCM CloudEvent carries the asserting party's BPN in its `source` attribute. The recipient
+**MUST** verify that `source` matches the authenticated identity of the sender and **MUST** reject the event when they
+do not match:
+
+- A Certificate Consumer **MUST** reject a certificate lifecycle or fulfillment notification (see
+  [Section 3.2.1](#321-certificate-lifecycle-events)) whose `source` does not match the authenticated Certificate
+  Provider.
+- A Certificate Provider **MUST** reject an acceptance status event (see
+  [Section 3.3.3](#333-certificate-acceptance)) whose `source` does not match the authenticated Certificate Consumer.
+
+**Document confidentiality.** Certificate documents are confidential. A document's `contentBase64` **MUST** be delivered
+inline only to a Certificate Consumer registered under the
+`cx-taxo:CompanyCertificateManagementConsumerEmbeddedDocumentApi` subject and authorized via its negotiated contract;
+document binaries (`GET /documents/{id}`) **MUST** be served only over the authenticated channel.
+
+### 3.2 Certificate Consumer API
 
 > API specification:
 > [Certificate Consumer API](assets/certificate-consumer-api.yaml)
 
-The Certificate Consumer API enables a Certificate Consumer to receive notifications from Certificate
-Provider (as certificate lifecycle events, see [Section 2.2](#22-certificate-lifecycle)) and provide certificate 
-acceptance status for open exchanges (see [Section 3.1.2](#312-certificate-acceptance-status)):
+The Certificate Consumer API enables a Certificate Consumer to receive notifications from Certificate Provider (as
+certificate lifecycle events, see [Section 2.2](#22-certificate-lifecycle)) and provide certificate acceptance status
+for open exchanges (see [Section 3.2.2](#322-certificate-acceptance-status-query)):
 
-This API is optional; a Certificate Consumer that does not wish to receive notifications or provide certificate 
-acceptance status updates is not required to implement it. A Certificate Consumer that does implement it **MUST** 
+This API is optional; a Certificate Consumer that does not wish to receive notifications or provide certificate
+acceptance status updates is not required to implement it. A Certificate Consumer that does implement it **MUST**
 adhere to the following normative requirements (as well as further requirements defined in this section):
-- The Certificate Consumer signals to the Certificate Provider the existence of the API by the availability of the
-  data asset. If no data asset is available, the Certificate Provider is relieved of their obligation to push
-  notifications. If the Certificate Consumer wishes to receive notifications, they **MUST** provide the data asset.
+
+- The Certificate Consumer signals to the Certificate Provider the existence of the API by the availability of the data
+  asset. If no data asset is available, the Certificate Provider is relieved of their obligation to push notifications.
+  If the Certificate Consumer wishes to receive notifications, they **MUST** provide the data asset.
 - If the data asset exists, the Certificate Consumer **MUST** serve all specified endpoints and implement at least one
-  of them, but **MAY** return `HTTP 501` for endpoints it does not wish to implement.
-  For example, a consumer that wants to receive notifications but does not want to provide acceptance status updates 
-  could return `HTTP 501` for the acceptance status endpoint.
-- reference the name of the Certificate Provider API: `cx-taxo:CompanyCertificateManagementConsumerApi` for the property
-  [[subject]](http://purl.org/dc/terms/subject).
+  of them, but **MAY** return `HTTP 501` for endpoints it does not wish to implement. For example, a Consumer that wants
+  to receive notifications but does not want to provide acceptance status updates could return `HTTP 501` for the
+  acceptance status endpoint.
+- reference, for the property [[subject]](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#subject),
+  exactly one of the two Certificate Consumer API subjects: `cx-taxo:CompanyCertificateManagementConsumerApi` (lifecycle
+  notifications carry document references only) or `cx-taxo:CompanyCertificateManagementConsumerEmbeddedDocumentApi`
+  (lifecycle notifications additionally embed inline documents, see [Section 3.2.1](#321-certificate-lifecycle-events)).
 - reference the version of the API according to the OpenAPI specification for the property
-  [[version]](https://w3id.org/catenax/ontology/common#version): `1.0`
+  [[version]](https://w3id.org/catenax/ontology/common#version): `3.0`
 
 A Certificate Provider **MUST** push notifications to a Certificate Consumer that implements this API (and therefore
-**MUST** check for its existence), and **MUST** follow the requirements defined in this section when doing so.
+**MUST** check for its existence), and **MUST** follow the requirements defined in this section when doing so. This
+obligation applies only to the endpoints the Certificate Consumer actually serves: if the Certificate Consumer returns
+`HTTP 501` for an endpoint (see above), the Certificate Provider is relieved of the obligation to push to that endpoint.
+Polling (`GET /certificate-requests/{id}`, [Section 3.3.1](#331-certificate-request)) remains available as a fallback
+and is not a substitute for the push obligation.
 
-The API is based on CloudEvents (see [CloudEvents](#cloudevents)) and **MUST** follow the HTTP binding defined in 
+The API is based on CloudEvents (see [CloudEvents](#cloudevents)) and **MUST** follow the HTTP binding defined in
 [CloudEvents-HTTP](#cloudevents-http).
 
-**Example Certificate EDC Asset:**
-
-___
-```json
-{
-  "@id": "81a0bdf8-732f-488e-bddb-1b9a78f0d1e0",
-  "@type": "Asset",
-  "properties": {
-    "dct:type": {
-      "@id": "cx-taxo:CCMAPI"
-    },
-    "dct:subject": {
-      "@id": "cx-taxo:CompanyCertificateManagementConsumerApi"
-    },
-    "dct:description": "API for receiving certificate lifecycle notifications.",
-    "cx-common:version": "1.0"
-  },
-  "dataAddress": {
-      "@type": "DataAddress",
-      "type": "HttpData",
-      "baseUrl": "https://backend-base-url/certificate-consumer-api-base-path",
-      "proxyQueryParams": "false",
-      "proxyPath": "true",
-      "proxyMethod": "false",
-      "proxyBody": "true"
-    },
-  "@context": {
-    "dct": "http://purl.org/dc/terms/",
-    "cx-taxo": "https://w3id.org/catenax/taxonomy#",
-    "cx-common": "https://w3id.org/catenax/ontology/common#"
-  }
-}
-```
-___
-
-#### 3.1.1 Certificate Lifecycle Events
+#### 3.2.1 Certificate Lifecycle Events
 
 `POST /certificate-notifications`
 
-The endpoint accepts a single CloudEvent or a batch (a JSON array) and follows the state machine defined in 
+The endpoint accepts a single CloudEvent or a batch (a JSON array) and follows the state machine defined in
 [Section 2.1.3](#213-state-machine-certificate-exchange).
 
-The event **MUST** be one of the following **Event Type**: 
+The event **MUST** be one of the following **Event Type**:
+
 - `org.catena-x.ccm.CertificateLifecycleStatus.v1`
 - `org.catena-x.ccm.CertificateFulfillmentStatus.v1`
 
-The Certificate Provider **MUST** push notifications for all states from 
-[2.2.2 State Machine](#222-state-machine-certificate-lifecycle) as Certificate Lifecycle Status.
-An example notification history could be:
-The Certificate Provider pushes a `CREATED` notification (this would always be the case), and a few days later a 
-`MODIFIED` notification, because an error in the certificate metadata had to be corrected. A few years later the
-provider could push a `WITHDRAWN` notification, because the certificate is no longer valid. This last step is not
-mandatory, because a provider could decide to still keep the certificate available, even if it is expired.
+The Certificate Provider **MUST** push notifications for all states from
+[2.2.2 State Machine](#222-state-machine-certificate-lifecycle) as Certificate Lifecycle Status. An example notification
+history could be:
+The Certificate Provider pushes a `CREATED` notification (this would always be the case), and a few days later a
+`MODIFIED` notification, because an error in the certificate record had to be corrected. A few years later the Provider
+could push a `WITHDRAWN` notification, because the certificate is no longer valid. This last step is not mandatory,
+because a Provider could decide to still keep the certificate available, even if it is expired.
 
-The Certificate Provider **MUST** also push notifications for all provider owned terminal states from 
+The `data` payload of a Certificate Lifecycle Status event has the following top-level structure:
+
+| Property      | Type   | Presence                | Description                                                                                                                                            |
+|---------------|--------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `status`      | String | MANDATORY               | One of `CREATED`, `MODIFIED`, `WITHDRAWN`.                                                                                                             |
+| `exchangeId`  | String | MANDATORY for `CREATED` | Identifier of the provider-initiated exchange opened by the `CREATED` event; absent otherwise.                                                         |
+| `certificate` | Object | MANDATORY               | The certificate record (see [Section 4](#4-aspect-models)). How much of it is populated depends on the Certificate Consumer's API subject (see below). |
+
+The field set carried inside `certificate` for a `CREATED`/`MODIFIED` event depends on which Certificate Consumer API
+subject the Consumer registered (see [Section 3.2](#32-certificate-consumer-api)):
+
+| `certificate` field                                                  | Baseline (`…ConsumerApi`) | Embedded (`…ConsumerEmbeddedDocumentApi`)      |
+|----------------------------------------------------------------------|---------------------------|------------------------------------------------|
+| `certificateId`                                                      | MANDATORY                 | MANDATORY                                      |
+| `revision`                                                           | MANDATORY                 | MANDATORY                                      |
+| `certificateType`                                                    | MANDATORY                 | MANDATORY                                      |
+| `validFrom`, `validUntil`                                            | MANDATORY                 | MANDATORY                                      |
+| `registrationNumber`, `trustLevel`                                   | absent                    | MANDATORY                                      |
+| `certifiedLocations`                                                 | absent                    | MANDATORY                                      |
+| `certificateTypeVersion`, `areaOfApplication`, `issuer`, `validator` | absent                    | OPTIONAL                                       |
+| `documents`                                                          | absent                    | MANDATORY, each entry carrying `contentBase64` |
+
+The baseline subset lets a Consumer triage relevance (type, validity) without retrieving. The embedded form carries the
+**complete** certificate record — identical to the `GET /certificates/{id}` response
+([Section 3.3.2](#332-certificate-retrieval)) — plus the inline document content, so an opted-in Consumer needs no
+separate retrieval. A `WITHDRAWN` event carries only `certificate.certificateId` (with `status`).
+
+The Certificate Provider **MUST** also push notifications for all provider-owned terminal states from
 [2.1.3 State Machine](#213-state-machine-certificate-exchange) as Certificate Fulfillment Status.
 
 > [!Important]
 > **Push Mechanism explanation**
-> 
+>
 > Previous versions of the standard made a distinction between a dedicated push and a pull mechanism.
 > This standard consolidates both into a single mechanism.
 > To still support the push mechanism, the Certificate Lifecycle Events endpoint has a unique functionality.
-> Usually the notification would not contain any certificate payload, but only lifecycle events.
-> However, the following will explain how a lifecycle event **MAY** also carry a certificate payload.
+> Usually the notification carries only the lifecycle event, without any document content.
+> However, the following explains how a lifecycle event **MAY** also carry the certificate's documents inline.
 
-Certificate Consumers that want to receive also certificate payload with their lifecycle events, they can do 
-the following way: When registering the asset as described in the previous section [3.1](#31-certificate-consumer-api), 
-the Certificate Consumer **MUST** add the `property`:
+A Certificate Consumer that wants the full certificate record and document content delivered inline with its lifecycle
+events registers its Certificate Consumer API asset under the subject
+`cx-taxo:CompanyCertificateManagementConsumerEmbeddedDocumentApi` instead of
+`cx-taxo:CompanyCertificateManagementConsumerApi` (see [Section 3.2](#32-certificate-consumer-api)). The two subjects
+describe the same endpoints; they differ only in how much of `data.certificate` is populated on `CREATED`/`MODIFIED`
+notifications. A Certificate Consumer **MUST** register exactly one of the two Consumer subjects.
+
+When the Certificate Consumer's asset declares the plain `cx-taxo:CompanyCertificateManagementConsumerApi` subject, the
+Certificate Provider **MUST** populate `data.certificate` with the triage subset only (`certificateId`,
+`revision`, `certificateType`, `validFrom`, `validUntil`) and **MUST NOT** include `registrationNumber`, `trustLevel`,
+`certifiedLocations`, `issuer`, `validator`, or `documents`.
+
+When the Certificate Consumer's asset declares the `cx-taxo:CompanyCertificateManagementConsumerEmbeddedDocumentApi`
+subject, the Certificate Provider **MUST**, for `CREATED`/`MODIFIED` events, populate `data.certificate` with the
+**complete** certificate record as defined for `GET /certificates/{id}` ([Section 3.3.2](#332-certificate-retrieval)),
+**and MUST** include the `documents` array. Each document entry **MUST** contain `documentId`, `createdDate`,
+`mediaType`, and `contentBase64`, and **MAY** contain `language`. (Unlike the retrieval response, where document content
+is forbidden, embedded documents **MUST** include `contentBase64`.)
+
+For a `WITHDRAWN` event (either subject), `data.certificate` carries only `certificateId`. Fulfillment events
+(`org.catena-x.ccm.CertificateFulfillmentStatus.v1`) never carry a certificate record.
+
+The above **MUST** also be respected for batch notifications.
+
+The following is a non-normative example of a `CREATED` notification to a Consumer registered under the
+`cx-taxo:CompanyCertificateManagementConsumerApi` subject:
 
 ```json
 {
-  "dct:notification-payload": {
-    "@id": "true"
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+  "time": "2025-05-04T07:00:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "status": "CREATED",
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificate": {
+      "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+      "revision": 1,
+      "certificateType": "iso9001",
+      "validFrom": "2023-01-25",
+      "validUntil": "2026-01-24"
+    }
   }
 }
 ```
 
-The Certificate Provider **MUST** check for the presence of this property when pushing the lifecycle events `CREATED` or 
-`MODIFIED` and, if the property is set, include the certificate payload in the `data` section of the CloudEvent.
-The certificate payload **MUST** be according to [Section 5](#5-certificate-data-model), with the following caveat:
-The `contentBase64` property **MUST** be included. For any other lifecycle event, the Certificate Provider **MUST NOT** 
-include the certificate payload in the notification, even if the property is set.
+The following is a non-normative example of a `CREATED` notification to a Consumer registered under the
+`CompanyCertificateManagementConsumerEmbeddedDocumentApi` subject:
 
-If the `dct:notification-payload` is either omitted or `"false"`, then the Certificate Provider **MUST NOT** include the 
-certificate payload in the `data` section of the CloudEvent.
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateLifecycleStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "e7c9a1b2-3d4e-5f6a-7b8c-9d0e1f2a3b4c",
+  "time": "2025-05-04T07:00:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "status": "CREATED",
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificate": {
+      "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+      "revision": 1,
+      "certificateType": "iso9001",
+      "registrationNumber": "12 100 4711",
+      "validFrom": "2023-01-25",
+      "validUntil": "2026-01-24",
+      "trustLevel": "high",
+      "certifiedLocations": [
+        {
+          "bpnl": "BPNL00000001AXS",
+          "bpna": "BPNA00000001AXS",
+          "bpns": "BPNS00000001AXS",
+          "locationRole": "MAIN_LOCATION"
+        }
+      ],
+      "documents": [
+        {
+          "documentId": "doc-3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "createdDate": "2023-01-25",
+          "language": "en",
+          "mediaType": "application/pdf",
+          "contentBase64": "JVBERi0xLjQKJ..."
+        }
+      ]
+    }
+  }
+}
+```
 
-The above **MUST** also be respected for batch notifications.
+A Certificate Provider pushes a **fulfillment status** notification to report the outcome of a Consumer's certificate
+request, such as the certificate becoming available (`FULFILLED`). The following is a non-normative example of a
+**fulfillment status** notification:
 
-#### 3.1.2 Certificate Acceptance Status Query
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateFulfillmentStatus.v1",
+  "source": "urn:bpn:BPNL0000000001AB",
+  "subject": "BPNL0000000002CD",
+  "id": "f0e1d2c3-b4a5-6789-0abc-def012345678",
+  "time": "2025-05-04T07:30:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "FULFILLED"
+  }
+}
+```
+
+When `status` is `DECLINED` or `FAILED`, the `data` **MUST** also include a non-empty `errors` array (for example,
+`"errors": [ { "message": "Certificate type not offered for the requested location" } ]`).
+
+#### 3.2.2 Certificate Acceptance Status Query
 
 `GET  /certificate-acceptance-status/{id}`
 
-### 3.2 Certificate Provider API
+This endpoint allows a Certificate Provider to query the current acceptance status of a `Certificate Exchange` it
+opened. The `{id}` path parameter **MUST** be the `exchangeId` assigned when the exchange was opened (see
+[Section 2.1.1](#211-identity-and-correlation)). It is the pull counterpart of the acceptance status the Certificate
+Consumer otherwise reports via `POST /certificate-acceptance-notifications` (see
+[Section 3.3.3](#333-certificate-acceptance)); both convey an Acceptance-phase state (`RETRIEVED`, `ACCEPTED`,
+`REJECTED`, or `ERRORED`) of the Certificate Exchange as defined in
+[Section 2.1.3](#213-state-machine-certificate-exchange).
+
+If the `exchangeId` is unknown to the Certificate Consumer, it **MUST** respond with `HTTP 404`. A Certificate Consumer
+that does not implement this endpoint **MAY** respond with `HTTP 501` (see [Section 3.2](#32-certificate-consumer-api)).
+
+### 3.3 Certificate Provider API
 
 > API specification:
 > [Certificate Provider API](assets/certificate-provider-api.yaml)
@@ -499,100 +649,144 @@ The Certificate Provider API enables Certificate Providers to accept certificate
 status, serve certificate data, answer certificate queries, and receive acceptance status from Certificate Consumers.
 
 The Certificate Provider **MUST**:
+
 - implement this API in its total, supporting all endpoints.
 - reference the name of the Certificate Provider API: `cx-taxo:CompanyCertificateManagementProviderApi` for the property
-  [[subject]](http://purl.org/dc/terms/subject).
+  [[subject]](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#subject).
 - reference the version of the API according to the OpenAPI specification for the property
-  [[version]](https://w3id.org/catenax/ontology/common#version): `1.0`
+  [[version]](https://w3id.org/catenax/ontology/common#version): `3.0`
 
-**Example Certificate EDC Asset:**
-
-___
-```json
-{
-  "@id": "81a0bdf8-732f-488e-bddb-1b9a78f0d1e0",
-  "@type": "Asset",
-  "properties": {
-    "dct:type": {
-      "@id": "cx-taxo:CCMAPI"
-    },
-    "dct:subject": {
-      "@id": "cx-taxo:CompanyCertificateManagementProviderApi"
-    },
-    "dct:description": "API for requesting and searching certificates as well as documents, as well as to provide feedback.",
-    "cx-common:version": "1.0"
-  },
-  "dataAddress": {
-      "@type": "DataAddress",
-      "type": "HttpData",
-      "baseUrl": "https://backend-base-url/certificate-provider-api-base-path",
-      "proxyQueryParams": "false",
-      "proxyPath": "true",
-      "proxyMethod": "false",
-      "proxyBody": "true"
-    },
-  "@context": {
-    "dct": "http://purl.org/dc/terms/",
-    "cx-taxo": "https://w3id.org/catenax/taxonomy#",
-    "cx-common": "https://w3id.org/catenax/ontology/common#"
-  }
-}
-```
-___
-
-#### 3.2.1 Certificate Request
+#### 3.3.1 Certificate Request
 
 `POST /certificate-requests`,
 `GET  /certificate-requests/{id}`
 
-The Certificate Provider **MUST** respond with request states according to 
+The Certificate Provider **MUST** respond with request states according to
 [2.1.3 State Machine](#213-state-machine-certificate-exchange).
 
-#### 3.2.3 Certificate Retrieval
+#### 3.3.2 Certificate Retrieval
 
 `GET  /certificates/{id}`
 `GET  /documents/{id}`
 
-The `/certificates/{id}` endpoint **MUST** be based on [CX-0002](#cx-0002) and return the certificate submodel
-as defined in [Section 4.1](#41-aspect-model-business-partner-certificate).
+The `/certificates/{id}` endpoint **MUST** return the certificate as a JSON object conforming to the certificate data
+model defined in [Section 4.1](#41-aspect-model-business-partner-certificate), as specified by the
+[Certificate Provider API](assets/certificate-provider-api.yaml) OpenAPI specification.
 
-Any certificate as part of the `/certificates/{id}` response **MUST NOT** have the `contentBase64` property included,
-even if the consumer has registered for it in the notification payload
-(see [Section 3.1.1](#311-certificate-lifecycle-events)). To receive the document content, 
-the consumer **MUST** use the `/documents/{id}` based on the `documentId` property included in the certificate submodel.
+The `/certificates/{id}` response includes document references only and never the document content. To receive a
+document's content, the Consumer **MUST** either use `GET /documents/{id}` with the `documentId` from the certificate
+record, or — when it is registered under the embedded-document subject — receive it inline in the certificate embedded
+in a lifecycle notification (`data.certificate.documents[].contentBase64`, see
+[Section 3.2.1](#321-certificate-lifecycle-events)).
 
-#### 3.2.4 Certificate Acceptance 
+A **withdrawn** certificate (lifecycle state `WITHDRAWN`, see
+[Section 2.2](#22-certificate-lifecycle)) need not remain retrievable: for a withdrawn certificate the Provider **MAY**
+cease returning the certificate record and its documents. The Provider **MUST**, however, retain the fact that the
+certificate was withdrawn and make it observable — for a withdrawn `certificateId`, `GET /certificates/{id}` **MUST**
+return `HTTP 200` with the minimal status body `{ "certificateId": "…", "status": "WITHDRAWN" }` (no metadata or
+documents), so a Certificate Consumer that holds the `certificateId` can confirm the withdrawal via the Certificate
+Provider API even after the certificate data is no longer served. An unknown `certificateId` still returns `HTTP 404`.
+
+#### 3.3.3 Certificate Acceptance
 
 `POST /certificate-acceptance-notifications`
 
-This API is used by the Certificate Consumer to provide feedback on the status to the Certificate Provider, 
-either accepting or rejecting the provided certificate. It is based on CloudEvents (see [CloudEvents](#cloudevents)).
-The contents of the feedback message **MUST** be included in the `data` section of the CloudEvent, and set
-according to the lifecycle of the certificate exchange as defined in 
-[Section 2.1.3](#213-state-machine-certificate-exchange).
+This API is used by the Certificate Consumer to provide feedback on the status to the Certificate Provider, either
+accepting or rejecting the provided certificate. It is based on CloudEvents (see [CloudEvents](#cloudevents)). The event
+**MUST** be of **Event Type** `org.catena-x.ccm.CertificateAcceptanceStatus.v1`. The contents of the feedback message
+**MUST** be included in the `data` section of the CloudEvent, with `data.status` set to one of the Acceptance-phase
+states (`RETRIEVED`, `ACCEPTED`, `REJECTED`, `ERRORED`) according to the lifecycle of the Certificate Exchange as
+defined in [Section 2.1.3](#213-state-machine-certificate-exchange).
 
-#### 3.2.5 Certificate Query
+The following is a non-normative example of an `ACCEPTED` acceptance status event:
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateAcceptanceStatus.v1",
+  "source": "urn:bpn:BPNL0000000002CD",
+  "subject": "BPNL0000000001AB",
+  "id": "a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d",
+  "time": "2025-05-04T09:00:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "ACCEPTED"
+  }
+}
+```
+
+For `REJECTED` or `ERRORED`, the `data` **MUST** include a non-empty `errors` array; each error has a `message` and an
+optional `specifier` scoping it to a certificate element (for example, a site BPN):
+
+```json
+{
+  "specversion": "1.0",
+  "type": "org.catena-x.ccm.CertificateAcceptanceStatus.v1",
+  "source": "urn:bpn:BPNL0000000002CD",
+  "subject": "BPNL0000000001AB",
+  "id": "f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c",
+  "time": "2025-05-04T09:00:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "exchangeId": "exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44",
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "status": "REJECTED",
+    "errors": [
+      {
+        "message": "Certificate has expired"
+      },
+      {
+        "specifier": "BPNS000000000002",
+        "message": "Site BPNS000000000002 was rejected"
+      }
+    ]
+  }
+}
+```
+
+#### 3.3.4 Certificate Query
 
 `POST /certificates/search`
 
-The Certificate Provider **MUST** implement the search endpoint for certificates according to the 
-Registry Service Specification - Query Profile (SSP-004) defined in [CX-0002](#cx-0002). This hard requirement
-is softened in the following way:
-- The only logical expressions that **MUST** be supported (all others **MAY** be supported) are:
-  - `$match`
-  - `$eq`
-- The only fields that **MUST** be supported (all others **MAY** be supported) are:
-  - `certifiedLocations.bpnl`
-  - `certifiedLocations.bpns`
-  - `certifiedLocations.bpna`
-  - `type.certificateType`
-- Therefore, the only matches that **MUST** be supported (all others **MAY** be supported) are:
-  - `$field`: `certifiedLocations.bpnl`, `$eq`: any valid BPNL as string.
-  - `$field`: `certifiedLocations.bpns`, `$eq`: any valid BPNS as string.
-  - `$field`: `certifiedLocations.bpna`, `$eq`: any valid BPNA as string.
-  - `$field`: `type.certifcateType`, `$eq`: any allowed certificate type.
+The Certificate Provider **MUST** expose a search endpoint at `POST /certificates/search` that accepts the constrained
+query structure defined in this section. The request body **MUST** be a single JSON object with the following structure:
+
+- `$condition` — the root of the query (**MANDATORY**).
+- `$match` — an array of comparison clauses. A certificate matches only if it satisfies **every** clause in the array
+  (logical **AND**).
+- Each clause **MUST** be an object with:
+    - `$field` — a string path identifying the field to compare, referencing the certificate data model
+      (see [Section 4.1](#41-aspect-model-business-partner-certificate)).
+    - `$eq` — the string value the field **MUST** equal.
+
+A Certificate Provider **MUST** support exactly the following subset and **MAY** support more:
+
+- Operators: `$match`, `$eq`.
+- Fields: `certifiedLocations.bpnl`, `certifiedLocations.bpns`, `certifiedLocations.bpna`, `certificateType`.
+- Matches, each as a `{$field, $eq}` clause:
+    - `$field`: `certifiedLocations.bpnl`, `$eq`: any valid BPNL as string.
+    - `$field`: `certifiedLocations.bpns`, `$eq`: any valid BPNS as string.
+    - `$field`: `certifiedLocations.bpna`, `$eq`: any valid BPNA as string.
+    - `$field`: `certificateType`, `$eq`: any allowed certificate type.
+
+A Certificate Provider that receives a query using an operator or field it does not support **MUST** reject the request
+with `HTTP 501`.
+
+The response body **MUST** be a JSON array of certificate records, each carrying the full certificate metadata for the
+latest `revision` (without document binaries), as defined by the
+[Certificate Provider API](assets/certificate-provider-api.yaml) OpenAPI specification. A Certificate Consumer retrieves
+a certificate via `GET /certificates/{id}` using its `certificateId`. Implementations **MAY**
+paginate the results; when they do, pagination **MUST** be conveyed using Web Linking ([RFC8288](#rfc8288)) via the HTTP
+`Link` response header, supporting at least the `next` and `prev` relations.
+
+> **Note (non-normative):** the query structure above is a constrained profile of, and wire-compatible with, the
+> Registry Service Specification — Query Profile (SSP-004) referenced by [CX-0002](#cx-0002). Conformance to this
+> standard requires only the subset defined in this section; implementing SSP-004 in full is **NOT** required.
 ___
-**Example query 1**
+**Example query 1** *(non-normative)*
+
 ```json
 {
   "$condition": {
@@ -613,12 +807,15 @@ ___
   }
 }
 ```
+
 This example would return all certificates that match all the following conditions:
+
 - the certificate contains a certifiedLocations with BPNL: `BPNL00000001AXS`
 - and the certificate contains a certifiedLocations with BPNS: `BPNS00000001AXS`
 - and the certificate contains a certifiedLocations with BPNA: `BPNA00000001AXS`
 
-**Example query 2**
+**Example query 2** *(non-normative)*
+
 ```json
 {
   "$condition": {
@@ -628,65 +825,106 @@ This example would return all certificates that match all the following conditio
         "$eq": "BPNL00000001AXS"
       },
       {
-        "$field": "type.certificateType",
+        "$field": "certificateType",
         "$eq": "iso14001"
       }
     ]
   }
 }
 ```
+
 This example would return all certificates that match all the following conditions:
+
 - the certificate contains a certifiedLocations with BPNL: `BPNL00000001AXS`
 - and the certificate has the certificate type `iso14001`
+
+**Example query result** *(non-normative)*
+
+The response to a query (for example, Example query 2 above) is a JSON array of certificate records. Each record carries
+the full certificate metadata for the latest `revision`; document content is never included — a Consumer retrieves a
+document binary via `GET /documents/{id}` using its `documentId`.
+
+```json
+[
+  {
+    "certificateId": "cert-550e8400-e29b-41d4-a716-446655440000",
+    "revision": 1,
+    "certificateType": "iso14001",
+    "certificateTypeVersion": "2015",
+    "registrationNumber": "12 100 4711",
+    "validFrom": "2023-01-25",
+    "validUntil": "2026-01-24",
+    "trustLevel": "high",
+    "certifiedLocations": [
+      {
+        "bpnl": "BPNL00000001AXS",
+        "bpna": "BPNA00000001AXS",
+        "bpns": "BPNS00000001AXS",
+        "locationRole": "MAIN_LOCATION"
+      }
+    ],
+    "issuer": {
+      "issuerName": "TÜV Süd",
+      "issuerBpn": "BPNL0000000003EF"
+    },
+    "documents": [
+      {
+        "documentId": "doc-3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "createdDate": "2023-01-25",
+        "language": "en",
+        "mediaType": "application/pdf"
+      }
+    ]
+  }
+]
+```
+
 ___
 
-#### 3.3 Policy Constraints for Data Exchange
+### 3.4 Policy Constraints for Data Exchange
 
-In alignment with the commitment to data sovereignty, a framework governing the use of data within the Catena-X use
-cases has been defined. As part of this framework, conventions for access policies, usage policies, and the constraints
-they contain are specified in [CX-0152](#cx-0152) Policy Constraints for Data Exchange. [CX-0152](#cx-0152) **MUST** be
-followed when providing services or applications for sharing or consuming data, and when sharing or consuming data, in
-the Catena-X ecosystem. Which conventions are relevant for which roles named in [Chapter 1.1](#11-audience--scope) 
-is specified in [CX-0152](#cx-0152) as well.
+Access and usage policies for the CCM APIs and certificate datasets **MUST** conform to [CX-0152](#cx-0152); the
+specific CCM usage policy is defined in [Section 3.5](#35-usage-policy).
 
-#### 3.4 Usage Policy
+### 3.5 Usage Policy
 
-All dataspace offers of a participant — both the APIs defined in this standard and the certificate datasets — **MUST**
-carry a usage policy following the requirements referenced in 
-[Section 4.5.1](#451-policy-constraints-for-data-exchange). This use case introduces the following usage purpose:
+All dataspace offers — both the APIs defined in this standard and the certificate datasets — **MUST** carry a usage
+policy following the requirements referenced in [Section 3.4](#34-policy-constraints-for-data-exchange). This use case
+introduces the following usage purpose:
 
 - **`cx.ccm.base:1`** — *the legal meaning is defined in [CX-0152](#cx-0152) (see the Catena-X standard library).*
 
-Additional, more general usage policies **MAY** be included, but every usage policy **MUST** contain the usage purpose
-above, as shown below.
+Additional, more general usage policies **MAY** be included, but every usage policy **MUST** contain the previous usage
+purpose, as shown below.
 
-*Minimal example of a usage policy without a contract reference:*
+The usage policy is carried under the offering Dataset's `odrl:hasPolicy` — it is part of a Dataset (see
+[Section 3.6](#36-dsp-dataset-representation) for the complete Dataset, including its `@context`). The following
+illustrates a non-normative minimal policy offer:
 
 ```json
 {
-  "@context": [
-    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
-    "https://w3id.org/catenax/2025/9/policy/context.jsonld"
-  ],
-  "@type": "Set",
-  "@id": "CCMAPI-usage-policy-without-contract-reference",
-  "permission": [
+  "odrl:hasPolicy": [
     {
-      "action": "use",
-      "constraint": {
-        "and": [
-          {
-            "leftOperand": "FrameworkAgreement",
-            "operator": "eq",
-            "rightOperand": "DataExchangeGovernance:1.0"
-          },
-          {
-            "leftOperand": "UsagePurpose",
-            "operator": "isAnyOf",
-            "rightOperand": "cx.ccm.base:1"
+      "@id": "CCMAPI-usage-policy",
+      "permission": [
+        {
+          "action": "use",
+          "constraint": {
+            "and": [
+              {
+                "leftOperand": "FrameworkAgreement",
+                "operator": "eq",
+                "rightOperand": "DataExchangeGovernance:1.0"
+              },
+              {
+                "leftOperand": "UsagePurpose",
+                "operator": "isAnyOf",
+                "rightOperand": "cx.ccm.base:1"
+              }
+            ]
           }
-        ]
-      }
+        }
+      ]
     }
   ]
 }
@@ -703,29 +941,163 @@ exists:
 }
 ```
 
+### 3.6 DSP Dataset Representation
+
+> *This section is non-normative.*
+
+A participant offers each supported API as a Dataset in its Dataspace Protocol catalog
+(see [DSP-Catalog](#dsp-catalog)). The Dataset carries the API's `dct:type`, `dct:subject`, and `cx-common:version` (per
+the asset table in [Section 3](#3-application-programming-interfaces)) together with a usage policy as required by
+[Section 3.5](#35-usage-policy). The following are non-normative examples.
+
+*Certificate Consumer API dataset (a Consumer wanting inline documents would instead use the subject
+`cx-taxo:CompanyCertificateManagementConsumerEmbeddedDocumentApi`):*
+
+```json
+{
+  "@context": [
+    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/catenax/2025/9/policy/context.jsonld",
+    {
+      "dcat": "http://www.w3.org/ns/dcat#",
+      "dct": "http://purl.org/dc/terms/",
+      "odrl": "http://www.w3.org/ns/odrl/2/",
+      "cx-taxo": "https://w3id.org/catenax/taxonomy#",
+      "cx-common": "https://w3id.org/catenax/ontology/common#"
+    }
+  ],
+  "@id": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
+  "dct:type": {
+    "@id": "cx-taxo:CCMAPI"
+  },
+  "dct:subject": {
+    "@id": "cx-taxo:CompanyCertificateManagementConsumerApi"
+  },
+  "dct:description": "Certificate Consumer API — receives certificate lifecycle notifications and serves acceptance status.",
+  "cx-common:version": "3.0",
+  "odrl:hasPolicy": [
+    {
+      "@id": "CCMAPI-consumer-usage-policy",
+      "permission": [
+        {
+          "action": "use",
+          "constraint": {
+            "and": [
+              {
+                "leftOperand": "FrameworkAgreement",
+                "operator": "eq",
+                "rightOperand": "DataExchangeGovernance:1.0"
+              },
+              {
+                "leftOperand": "UsagePurpose",
+                "operator": "isAnyOf",
+                "rightOperand": "cx.ccm.base:1"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "dcat:distribution": [
+    {
+      "dct:format": {
+        "@id": "HttpData-PULL"
+      },
+      "dcat:accessService": {
+        "@id": "urn:uuid:4aa2dcc8-4d2d-569e-d634-8394a8834d77"
+      }
+    }
+  ]
+}
+```
+
+*Certificate Provider API dataset:*
+
+```json
+{
+  "@context": [
+    "https://w3id.org/catenax/2025/9/policy/odrl.jsonld",
+    "https://w3id.org/catenax/2025/9/policy/context.jsonld",
+    {
+      "dcat": "http://www.w3.org/ns/dcat#",
+      "dct": "http://purl.org/dc/terms/",
+      "odrl": "http://www.w3.org/ns/odrl/2/",
+      "cx-taxo": "https://w3id.org/catenax/taxonomy#",
+      "cx-common": "https://w3id.org/catenax/ontology/common#"
+    }
+  ],
+  "@id": "urn:uuid:7b2e1f06-9c3a-4d51-8a2b-1f0c9d4e5a6b",
+  "dct:type": {
+    "@id": "cx-taxo:CCMAPI"
+  },
+  "dct:subject": {
+    "@id": "cx-taxo:CompanyCertificateManagementProviderApi"
+  },
+  "dct:description": "Certificate Provider API — requesting, retrieving and searching certificates and documents, and receiving acceptance status.",
+  "cx-common:version": "3.0",
+  "odrl:hasPolicy": [
+    {
+      "@id": "CCMAPI-provider-usage-policy",
+      "permission": [
+        {
+          "action": "use",
+          "constraint": {
+            "and": [
+              {
+                "leftOperand": "FrameworkAgreement",
+                "operator": "eq",
+                "rightOperand": "DataExchangeGovernance:1.0"
+              },
+              {
+                "leftOperand": "UsagePurpose",
+                "operator": "isAnyOf",
+                "rightOperand": "cx.ccm.base:1"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "dcat:distribution": [
+    {
+      "dct:format": {
+        "@id": "HttpData-PULL"
+      },
+      "dcat:accessService": {
+        "@id": "urn:uuid:9f4c2a18-6d7e-4b3a-9c1d-2e5f8a0b3c4d"
+      }
+    }
+  ]
+}
+```
+
 ## 4 ASPECT MODELS
 
 ### 4.1 ASPECT MODEL "Business Partner Certificate"
 
 > *This section is normative*
 
-The semantic model **MUST** use the unique identifier
+The certificate data model is defined normatively by [Section 4.2](#42-terminology) together with the
+`CertificateMetadata` schema of the [Certificate Provider API](assets/certificate-provider-api.yaml) OpenAPI
+specification. A certificate exchanged under this standard **MUST** conform to that data model.
 
-> urn:samm:io.catenax.business_partner_certificate:4.0.0
+A semantically equivalent SAMM aspect model (`io.catenax.business_partner_certificate`) is published separately as a
+non-normative convenience for tooling and semantic interoperability (see
+[io.catenax.business_partner_certificate](#sldt-business-partner-certificate-400)). Where that aspect model exists it
+**SHOULD** be consistent with this section; in case of any discrepancy, this standard takes precedence.
 
-and this model and version **MUST** be used for the certificate exchange.
-
-> **Note:**
-> - You can find the corresponding Turtle file [here](#sldt-business-partner-certificate-400).
-
-> **Important changes for version 4 of the aspect model:**
+> **Important changes introduced with this version of the data model (non-normative):**
 > - Introduction of versioning of a certificate (see lifecycle), with the property `revision`
-> - Removal of the property `enclosedSites` in favor of `certifiedLocations`, which has a more complex 
->   structure and allows to capture more details about the certified locations 
+> - Removal of the property `enclosedSites` in favor of `certifiedLocations`, which has a more complex
+>   structure and allows to capture more details about the certified locations
 >   (see [Section 4.2.4](#424-certified-locations))
-> - Changes to the property `document`, which is now an array of documents, that by default only has a `documentID` 
->   reference to the document file, and only contains the inline `contentBase64` content in a special case 
->   (see [Section 3.1](#31-certificate-consumer-api)). It also now explicitly states the `contentType`.
+> - Changes to the property `document`, which is now an array of documents. Each document is a **reference**
+>   (`documentId`, `createdDate`, `mediaType`, optional `language`) and does not carry content; the document content
+>   is delivered separately — as a binary via `GET /documents/{id}`, or inline as `contentBase64` in a lifecycle
+>   notification when the Consumer has opted in (see [Section 3.2.1](#321-certificate-lifecycle-events)). It now
+>   explicitly states the `mediaType`.
 
 ### 4.2 TERMINOLOGY
 
@@ -733,36 +1105,36 @@ and this model and version **MUST** be used for the certificate exchange.
 
 #### 4.2.1 CERTIFICATE TYPE
 
-The attribute *CertificateType* refers to the type of the certificate the BPN is certified for.
-This data model is generic and currently supports, but is not limited to, the following list of certificate types:
+The attribute *CertificateType* refers to the type of the certificate the BPN is certified for. This data model is
+generic and currently supports, but is not limited to, the following list of certificate types:
 
-- IATF 16949 (International Automotive Task Force) is a standard that defines the requirements for a quality management 
+- IATF 16949 (International Automotive Task Force) is a standard that defines the requirements for a quality management
   system in the automotive industry.
-- ISO 14001 is a standard that outlines the requirements for an environmental management system to help organizations 
+- ISO 14001 is a standard that outlines the requirements for an environmental management system to help organizations
   minimize their impact on the environment.
-- ISO 9001 is a standard that sets out the requirements for a quality management system to help organizations 
+- ISO 9001 is a standard that sets out the requirements for a quality management system to help organizations
   consistently provide products and services that meet customer and regulatory requirements.
-- ISO 45001, OHSAS 18001 or national certification are occupational health and safety management system standards that 
+- ISO 45001, OHSAS 18001 or national certification are occupational health and safety management system standards that
   help companies identify and manage workplace hazards to prevent accidents and injuries.
-- ISO/IEC 27001 is an information security management system standard that provides a framework for companies to manage 
+- ISO/IEC 27001 is an information security management system standard that provides a framework for companies to manage
   and protect their sensitive information.
-- ISO 50001 or national certification is an energy management system standard that helps companies improve energy 
+- ISO 50001 or national certification is an energy management system standard that helps companies improve energy
   efficiency and reduce costs.
-- ISO/IEC 17025 is a laboratory accreditation standard that ensures the accuracy and reliability of testing and 
+- ISO/IEC 17025 is a laboratory accreditation standard that ensures the accuracy and reliability of testing and
   calibration results.
-- ISO 20000 is an IT service management system standard that helps companies deliver high-quality IT services to 
-  their customers.
-- ISO 22301 is a business continuity management system standard that helps companies prepare for and respond to 
+- ISO 20000 is an IT service management system standard that helps companies deliver high-quality IT services to their
+  customers.
+- ISO 22301 is a business continuity management system standard that helps companies prepare for and respond to
   unexpected disruptions to their operations.
-- AEO (Authorized Economic Operator), CTPAT (Customs-Trade Partnership Against Terrorism), Security Declaration is an 
-  internationally recognized certificate that confirms a company's compliance with customs regulations and supply chain 
-  security standards. CTPAT (Customs-Trade Partnership Against Terrorism) is a voluntary program that promotes supply 
-  chain security and trade compliance with U.S. Customs and Border Protection. Security Declaration is a document that 
+- AEO (Authorized Economic Operator), CTPAT (Customs-Trade Partnership Against Terrorism), Security Declaration is an
+  internationally recognized certificate that confirms a company's compliance with customs regulations and supply chain
+  security standards. CTPAT (Customs-Trade Partnership Against Terrorism) is a voluntary program that promotes supply
+  chain security and trade compliance with U.S. Customs and Border Protection. Security Declaration is a document that
   outlines a company's security measures and procedures for the transportation of goods.
-- VDA6.4 is a standard that defines the requirements for a quality management system in the automotive industry, with a 
+- VDA6.4 is a standard that defines the requirements for a quality management system in the automotive industry, with a
   focus on process auditing.
 
-Additional certificate types will be validated in the future, and others may already be compatible with this generic 
+Additional certificate types will be validated in the future, and others may already be compatible with this generic
 model.
 
 For the exchange certificate types you **MUST** adhere to the following spelling rules:
@@ -791,68 +1163,68 @@ Applying these rules to the supported list of certificate types leads to the fol
 
 #### 4.2.2 REGISTRATION AND ISSUING
 
-The issuing authority is the authority that issues a certificate - e.g. TÜV Süd.
-The registration number is the unique identifier of the certificate at the certification authority / issuing body.
+The issuing authority is the authority that issues a certificate - e.g. TÜV Süd. The registration number is the unique
+identifier of the certificate at the certification authority / issuing body.
 
 Example: ISO 9001 certificate is issued by TÜV Süd, which is the certification authority.
 
 #### 4.2.3 AREA OF APPLICATION
 
-The attribute *areaOfApplication* refers the area of applications for the given certification i.e. additional details.
+The attribute *areaOfApplication* refers the area of applications for the given certification, i.e. additional details.
 
 #### 4.2.4 Certified Locations
 
-Each entry of a certified location in the data **MUST** represent exactly one certified location as stated on the 
+Each entry of a certified location in the data **MUST** represent exactly one certified location as stated on the
 certificate document. They **MUST** follow this structure and cardinality:
 
 | Field               | Cardinality (schema) | Normative                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                |
 |---------------------|----------------------|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `bpnl`              | 1..1                 | —                          | Legal entity the location belongs to. Enables group/matrix certificates across multiple legal entities. For the `MAIN_LOCATION` entry this is also the certificate holder.                                                                                                                                                                                                                                                                 |
-| `bpna`              | **1..1**             | **MANDATORY**              | **Golden Record anchor.** Mandatory for every entry. Where the certificate prints a postal address, the BPNA is resolved by matching that address against the Golden Record (document-verifiable). Where no address is printed for a stated location, the data provider selects the corresponding BPNA from the Golden Record (site main address or legal address) — a provider statement analogous to the BPNS selection (rules 3. & 4.). |
+| `bpna`              | **1..1**             | **MANDATORY**              | **Golden Record anchor.** Mandatory for every entry. Where the certificate prints a postal address, the BPNA is resolved by matching that address against the Golden Record (document-verifiable). Where no address is printed for a stated location, the data Provider selects the corresponding BPNA from the Golden Record (site main address or legal address) — a Provider statement analogous to the BPNS selection (rules 3. & 4.). |
 | `bpns`              | 0..1                 | **MANDATORY**, if assigned | Site the BPNA is assigned to in the Golden Record. Not printed on the certificate, therefore not document-verifiable; taken over from the Golden Record (rule 4.).                                                                                                                                                                                                                                                                         |
 | `locationRole`      | 1..1                 | —                          | Role as stated on the certificate. **MUST** be one of the following: `MAIN_LOCATION`, `ENCLOSED_LOCATION`, `REMOTE_SUPPORT_LOCATION`, `EXTENDED_MANUFACTURING_SITE`                                                                                                                                                                                                                                                                        |                                                                                                                                                                                                                                                                                                                                                                      |                                                                                                                                                                                                                                                                                                   |
 | `areaOfApplication` | 0..1                 | **MANDATORY**, if existent | Verbatim location-specific scope, only if explicitly printed (e.g. in the annex) (rule 6.).                                                                                                                                                                                                                                                                                                                                                |
 
-Certificate provisioning under this model requires the referenced master data to exist in the Golden Record before the 
-certificate data set is created ([CX-0010 Business Partner Number](#cx-0010); 
-Golden Record process per [CX-0074 Gate](#cx-0074) / [CX-0012 Pool](#cx-0012)). 
-If a printed address cannot be resolved to a BPNA, the data provider completes the Golden Record process for that 
-address first; the data set **MAY** be provided with the subset of resolved locations. 
-Application providers **SHOULD** support address→BPNA/S resolution (lookup/suggestion) during certificate data entry.
+Certificate provisioning under this model requires the referenced master data to exist in the Golden Record before the
+certificate data set is created ([CX-0010 Business Partner Number](#cx-0010); Golden Record process
+per [CX-0074 Gate](#cx-0074) / [CX-0012 Pool](#cx-0012)). If a printed address cannot be resolved to a BPNA, the data
+Provider completes the Golden Record process for that address first; the data set **MAY** be provided with the subset of
+resolved locations. Application Providers **SHOULD** support address→BPNA/S resolution (lookup/suggestion) during
+certificate data entry.
 
 The following rules **MUST** be complied with for adding certified locations:
-1. Exactly one entry in certifiedLocations **MUST** have locationRole = MAIN_LOCATION.
-2. The certificate holder is unambiguously derived as certifiedLocations[locationRole="MAIN_LOCATION"].bpnl.
-3. Every entry **MUST** contain a BPNA. Where the certificate prints a postal address for the location, 
-   the BPNA **MUST** be resolved by matching that address against the Golden Record (document-verifiable anchor). 
-   Where the certificate states a location without a (full) printed address, the data provider **MUST** select the BPNA 
-   from the Golden Record that corresponds to the stated location (site main address or legal-entity legal address); 
-   this selection is a provider statement. Locations that cannot be resolved to any BPNA **MUST NOT** be included; 
-   the data set **MAY** be provided with the subset of resolved locations.
-4. BPNS **MUST** be provided if the BPNA is assigned to at least one site in the Golden Record and **MUST** be omitted 
-   otherwise. If the BPNA is assigned to multiple sites, the data provider **MUST** select the BPNS that 
-   organizationally corresponds to the certified unit or function stated on the certificate; arbitrary or first-match 
+
+1. Exactly one entry in `certifiedLocations` **MUST** have locationRole = `MAIN_LOCATION`.
+2. The certificate holder is unambiguously derived as `certifiedLocations[locationRole="MAIN_LOCATION"].bpnl`.
+3. Every entry **MUST** contain a BPNA. Where the certificate prints a postal address for the location, the BPNA
+   **MUST** be resolved by matching that address against the Golden Record (document-verifiable anchor). Where the
+   certificate states a location without a (full) printed address, the data Provider **MUST** select the BPNA from the
+   Golden Record that corresponds to the stated location (site main address or legal-entity legal address); this
+   selection is a Provider statement. Locations that cannot be resolved to any BPNA **MUST NOT** be included; the data
+   set **MAY** be provided with the subset of resolved locations.
+4. BPNS **MUST** be provided if the BPNA is assigned to at least one site in the Golden Record and **MUST** be omitted
+   otherwise. If the BPNA is assigned to multiple sites, the data Provider **MUST** select the BPNS that
+   organizationally corresponds to the certified unit or function stated on the certificate; arbitrary or first-match
    selection is not conformant. The BPNS is derived from the Golden Record, not from the document.
 5. BPNA and BPNS of an entry **MUST** belong to the BPNL of the same entry (Golden Record consistency).
-6. The per-location areaOfApplication **MUST** only be set if a location-specific scope is explicitly stated on the 
-   certificate or its annex; otherwise it **MUST** be absent. The root areaOfApplication carries the overall scope 
-   statement verbatim. Every printed scope statement **MOST** appear exactly once in the payload.
-7. The trustLevel **MUST** reflect the verification process actually performed as defined in 
-   [Section 5.2.7](#527-trust-level).
-8. Interpretation logic (scope inheritance to subordinate addresses, hierarchy expansion) 
-   is explicitly out of scope of this standard and left to the certificate consumer.
+6. The per-location `areaOfApplication` **MUST** only be set if a location-specific scope is explicitly stated on the
+   certificate or its annex; otherwise it **MUST** be absent. The root `areaOfApplication` carries the overall scope
+   statement verbatim. Every printed scope statement **MUST** appear exactly once in the payload.
+7. The trustLevel **MUST** reflect the verification process actually performed as defined in
+   [Section 4.2.6](#426-trust-level).
+8. Interpretation logic (scope inheritance to subordinate addresses, hierarchy expansion)
+   is explicitly out of scope of this standard and left to the Certificate Consumer.
 
-#### 4.2.6 VALIDITY
+#### 4.2.5 VALIDITY
 
-The attribute *validity* refers to the date from which the certificate is valid.
-If it is not defined, it is recommended to use the date of issue/signature of the document.
-In connection with the valid-from date, there is the valid-to date for a certificate - 31.12.9999 for no expiration 
-date.
+The attribute *validity* refers to the date from which the certificate is valid. If it is not defined, it is recommended
+to use the date of issue/signature of the document. In connection with the valid-from date, there is the valid-to date
+for a certificate - `31.12.9999` for no expiration date.
 
-#### 4.2.7 TRUST LEVEL
+#### 4.2.6 TRUST LEVEL
 
-The following Trust Levels **MUST** be used. Each level builds upon the previous one and describes the verification 
-process actually performed, not a subjective rating. The distinguishing criterion between medium and high is the source 
+The following Trust Levels **MUST** be used. Each level builds upon the previous one and describes the verification
+process actually performed, not a subjective rating. The distinguishing criterion between medium and high is the source
 of the cross-check: third party vs. issuing authority.
 
 | Value    | Name                                  | Verification process                                                                                                                                                                                                                                                     |
@@ -872,24 +1244,22 @@ The subsequent migration guide **MUST** be followed when upgrading from a previo
 >| `high`    | `high` **or** `medium` | Depends on the cross-check source: issuing-authority interface (e.g. TÜV Süd, IATF) → `high`; third-party database (e.g. NQC, Ariba) → `medium`, provided the mandatory OCR validation is (re-)performed                                                |
 >| `trusted` | `high`                 | Direct issuer provisioning                                                                                                                                                                                                                              |
 
-#### 4.2.8 VALIDATOR
+#### 4.2.7 VALIDATOR
 
-The *validator* is the one who can validate certificate information.
-In the best way it is the authority that is issuing the certificates but there can be other validators.
-This attribute has a relation to the trust level.
+The *validator* is the entity that can validate the certificate record. Typically, it is the authority that is issuing
+the certificates, but there can be other validators. This attribute has a relation to the trust level. For example,
+business service providers that offer a validation service for company certificates.
 
-E.g. Business service providers that offer a validation service for company certificates.
+*Note*: The property `validatorBpn` is expected to be the BPNL by default. However, if deemed necessary, this property
+can be used as a free text field (string).
 
-*Note*: The property `validatorBpn` expects the BPNL as the default.
-However, if deemed necessary, this property can be used as a free text field (string).
+#### 4.2.8 CERTIFICATE UPLOADER
 
-#### 4.2.9 CERTIFICATE UPLOADER
+The attribute *uploader* defines the company (uploader) who originally provided the given certificate (e.g. company A
+provided it to Business Application Provider B, Business Application Provider B is a trusted validator). This company is
+also identified by a BPN.
 
-The attribute *uploader* defines the company (uploader) who originally provided the given certificate (e.g. company A 
-provided it to business application provider B, business application provider B is a trusted validator). 
-This company is also identified by a BPN.
-
-### 4.2.10 CERTIFICATE HOLDER
+#### 4.2.9 CERTIFICATE HOLDER
 
 The following rule **MUST** be complied with when determining the certificate holder:
 
@@ -898,38 +1268,42 @@ certificateHolder := certifiedLocations
   .filter(entry ⇒ entry.locationRole = "MAIN_LOCATION")[0]
   .bpnl
 ```
-#### 4.2.11 DOCUMENT
 
-A certificate document is a (usually binary) file that is issued by an issuing-authority (e.g. TÜV-Süd).
-Commonly it is a PDF file that contains the issued certificate in human-readable form.
-To support certificates that consist of multiple documents (e.g., different language versions), the data model
-supports documents in form of an array.
+#### 4.2.10 DOCUMENT
 
-Each document **MUST** have 
-- a unique identifier `documentId` (it is **RECOMMENDED** to use a UUID) that is resolvable under the mechanism 
-  described in [Section 3 APPLICATION PROGRAMMING INTERFACES](#3-application-programming-interfaces), 
+A certificate document is a (usually binary) file that is issued by an issuing-authority (e.g. TÜV-Süd). Commonly it is
+a PDF file that contains the issued certificate in human-readable form. To support certificates that consist of multiple
+documents (e.g., different language versions), the data model supports documents in the form of an array.
+
+Each document **MUST** have
+
+- a unique identifier `documentId` (it is **RECOMMENDED** to use a UUID) that is resolvable under the mechanism
+  described in [Section 3 APPLICATION PROGRAMMING INTERFACES](#3-application-programming-interfaces),
 - a `createdDate` that states when the document was created,
-- a `contentType` that states the media type of the document (e.g. `application/pdf`).
+- a `mediaType` that states the media type of the document (e.g. `application/pdf`).
 
-Each document **MAY** have a `contentBase64` that contains the Base64-encoded content of the document 
-itself, according to the mechanism described in [Section 3.1](#31-certificate-consumer-api) but **MUST NOT**
-have `contentBase64` property, under the mechanism described in [Section 3.2](#32-certificate-provider-api).
+Each document **MAY** have a `language` that states the document language as an [ISO 639-1](#iso6391) two-letter code
+(e.g. `en`, `de`), used to distinguish documents that differ only by language.
 
-#### 4.2.12 REVISION
+A certificate document carried in the certificate record returned by `GET /certificates/{id}`
+([Section 3.3.2](#332-certificate-retrieval)) or `/certificates/search` ([Section 3.3.4](#334-certificate-query)) is a
+**reference only** and **MUST NOT** contain the document content. The content is delivered either as a binary via
+`GET /documents/{id}` ([Section 3.3.2](#332-certificate-retrieval)), or — when the Certificate Consumer is registered
+under the embedded-document subject — inline as `contentBase64` on each document of the certificate embedded in a
+lifecycle notification (`data.certificate.documents[]`, see [Section 3.2.1](#321-certificate-lifecycle-events)).
 
-The `revision` property is a positive integer that is incremented with every update of the certificate information, 
-including changes that do not affect the certificate's versioning (for example, a change in the `trustLevel` 
-after re-validation does not affect the certificate version but requires incrementing the `revision` to signal 
-an update to clients). The initial value is `1` and it **MUST** be incremented by `1` for every update. 
-The `revision` **MUST** be included in the certificate query response and **MUST** be used for concurrency control 
-when retrieving or updating certificate information.
+#### 4.2.11 REVISION
+
+The `revision` property is a positive integer that is incremented with every update of the certificate record, including
+changes that do not affect the certificate's versioning (for example, a change in the `trustLevel`
+after re-validation does not affect the certificate version but requires incrementing the `revision` to signal an update
+to clients). The initial value is `1` and it **MUST** be incremented by `1` for every update. The `revision` **MUST** be
+included in the certificate query response. It identifies the certificate version: the latest `revision` is
+authoritative, and clients use it to detect that a newer revision exists and to pin the exact revision that a
+`Certificate Exchange` or acceptance feedback concerns.
 
 The `revision` is bound to the mechanism & statemachine described in [Section 2.2](#22-certificate-lifecycle)
-and its normative subchapter(s).
-
-___
-TODO additional rules?
-___
+and its normative subsection (s).
 
 ## 5 References
 
@@ -937,9 +1311,6 @@ ___
 
 <a id="cx-0000"></a>
 [CX-0000:1.0.0 Cloud Events](https://catenax-ev.github.io/docs/standards/CX-0000-CloudEventsFoundation).
-
-<a id="cx-0002"></a>
-[CX-0002:2.4.0 Digital Twins in Catena-X](https://catenax-ev.github.io/docs/next/standards/CX-0002-DigitalTwinsInCatenaX)
 
 <a id="cx-0010"></a>
 [CX-0010:3.1.0 Business Partner Number](https://catenax-ev.github.io/docs/standards/CX-0010-BusinessPartnerNumber)
@@ -952,9 +1323,6 @@ ___
 
 <a id="cx-0152"></a>
 [CX-0152:1.0.0 Policy Constraints for Data Exchange](https://catenax-ev.github.io/docs/standards/CX-0152-PolicyConstrainsForDataExchange)
-
-<a id="sldt-business-partner-certificate-400"></a>
-[io.catenax.business_partner_certificate#4.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.business_partner_certificate)
 
 <a id="cloudevents"></a>
 **[CloudEvents]** Cloud Native Computing Foundation, "CloudEvents 1.0.2 — Core Specification",
@@ -976,7 +1344,16 @@ languages — Part 1: Alpha-2 code", <https://www.iso.org/standard/22109.html>.
 **[RFC8174]** Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, May 2017,
 <https://www.rfc-editor.org/rfc/rfc8174>.
 
+<a id="rfc8288"></a>
+**[RFC8288]** Nottingham, M., "Web Linking", RFC 8288, October 2017, <https://www.rfc-editor.org/rfc/rfc8288>.
+
 ### 5.2 Non-Normative References
+
+<a id="cx-0002"></a>
+[CX-0002:2.4.0 Digital Twins in Catena-X](https://catenax-ev.github.io/docs/next/standards/CX-0002-DigitalTwinsInCatenaX)
+
+<a id="sldt-business-partner-certificate-400"></a>
+[io.catenax.business_partner_certificate#4.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.business_partner_certificate)
 
 <a id="cx-0012"></a>
 [CX-0012:5.1.1 Business Partner Data Pool API](https://catenax-ev.github.io/docs/next/standards/CX-0012-BusinessPartnerDataPoolAPI)
@@ -1016,4 +1393,5 @@ not applicable
 
 ## Legal
 
-Copyright © 2026 Catena-X Automotive Network e.V. All rights reserved. For more information, please see [Catena-X Copyright Notice](https://catenax-ev.github.io/copyright).
+Copyright © 2026 Catena-X Automotive Network e.V. All rights reserved. For more information, please
+see [Catena-X Copyright Notice](https://catenax-ev.github.io/copyright).

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/ccm-schemas.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/ccm-schemas.yaml
@@ -1,0 +1,202 @@
+# Shared CCM certificate data-model schemas.
+#
+# Defined once here and referenced by both the Certificate Provider API
+# (certificate-provider-api.yaml) and the Certificate Consumer API
+# (certificate-consumer-api.yaml), so the certificate record has a single source
+# of truth (CX-0135 §4). Per-context presence/strictness is layered on by the
+# referencing documents and the standard prose:
+#   - GET /certificates/{id} and /certificates/search wrap `Certificate` to make
+#     the full record mandatory and MUST NOT include document `contentBase64`
+#     (CX-0135 §3.3.2).
+#   - Lifecycle notifications embed `Certificate` as `data.certificate`; the
+#     populated field set depends on the consumer's API subject (CX-0135 §3.2.1).
+components:
+  schemas:
+    Certificate:
+      type: object
+      description: |
+        The certificate record (CX-0135 §4). Only `certificateId` is always
+        required at the schema level; which further fields are mandatory depends
+        on the context (retrieval vs. notification, and — for notifications — the
+        consumer's API subject), as defined by CX-0135 §3.3.2 and §3.2.1.
+      required:
+        - certificateId
+      properties:
+        certificateId:
+          type: string
+          description: Unique identifier of the certificate.
+          example: "cert-550e8400-e29b-41d4-a716-446655440000"
+        revision:
+          type: integer
+          description: The certificate revision (see CX-0135 §4.2.11).
+          example: 1
+        certificateType:
+          type: string
+          description: Opaque string identifying the certificate type (e.g. `iso9001`).
+          example: "iso9001"
+        certificateTypeVersion:
+          type: string
+          description: |
+            The version of the certificate type itself (e.g. `2015` for
+            ISO 9001:2015). Distinct from the certificate's `revision`.
+          example: "2015"
+        registrationNumber:
+          type: string
+          description: The certificate's registration number at the issuing body.
+          example: "12 100 4711"
+        validFrom:
+          type: string
+          format: date
+          description: |
+            Inclusive start date of the certificate validity period
+            (ISO 8601 full-date, `YYYY-MM-DD`).
+          example: "2023-01-25"
+        validUntil:
+          type: string
+          format: date
+          description: |
+            Inclusive end date of the certificate validity period
+            (ISO 8601 full-date, `YYYY-MM-DD`).
+          example: "2026-01-24"
+        trustLevel:
+          type: string
+          enum: [low, medium, high]
+          description: The degree to which the certificate has been validated.
+        areaOfApplication:
+          type: string
+          description: |
+            Free-text detail of the areas or application types the certificate is
+            valid for overall. Individual locations MAY narrow this via
+            `CertifiedLocation.areaOfApplication`.
+        certifiedLocations:
+          type: array
+          minItems: 1
+          description: |
+            The certified locations the certificate applies to (CX-0135 §4.2.4).
+            Exactly one entry MUST have `locationRole: MAIN_LOCATION`; its `bpnl`
+            is the certificate holder.
+          items:
+            $ref: '#/components/schemas/CertifiedLocation'
+        issuer:
+          $ref: '#/components/schemas/CertificateIssuer'
+        validator:
+          $ref: '#/components/schemas/CertificateValidator'
+        documents:
+          type: array
+          description: |
+            Documents associated with this certificate revision. Each entry is a
+            reference; the binary is retrieved via `GET /documents/{id}`, except
+            in a lifecycle notification to a consumer registered under the
+            `…ConsumerEmbeddedDocumentApi` subject, where each entry additionally
+            carries `contentBase64` (CX-0135 §3.2.1).
+          items:
+            $ref: '#/components/schemas/CertificateDocument'
+
+    CertifiedLocation:
+      type: object
+      description: |
+        One certified location as stated on the certificate (CX-0135 §4.2.4).
+        Exactly one entry in `certifiedLocations` MUST have
+        `locationRole: MAIN_LOCATION`; its `bpnl` is the certificate holder.
+      required:
+        - bpnl
+        - bpna
+        - locationRole
+      properties:
+        bpnl:
+          type: string
+          description: |
+            Legal entity the location belongs to. For the `MAIN_LOCATION` entry
+            this is also the certificate holder.
+          pattern: "^BPNL[a-zA-Z0-9]{12}$"
+        bpna:
+          type: string
+          description: Golden Record address anchor. Mandatory for every entry.
+          pattern: "^BPNA[a-zA-Z0-9]{12}$"
+        bpns:
+          type: string
+          description: |
+            Site the BPNA is assigned to in the Golden Record. MUST be present if
+            the BPNA is assigned to at least one site, omitted otherwise.
+          pattern: "^BPNS[a-zA-Z0-9]{12}$"
+        locationRole:
+          type: string
+          enum: [MAIN_LOCATION, ENCLOSED_LOCATION, REMOTE_SUPPORT_LOCATION, EXTENDED_MANUFACTURING_SITE]
+          description: The role of the location as stated on the certificate.
+        areaOfApplication:
+          type: string
+          description: |
+            Verbatim location-specific scope, set only if explicitly printed on
+            the certificate or its annex.
+
+    CertificateIssuer:
+      type: object
+      description: The authority that issued the certificate.
+      required:
+        - issuerName
+      properties:
+        issuerName:
+          type: string
+          description: The name of the issuing authority (e.g. `TÜV Süd`).
+        issuerBpn:
+          type: string
+          description: The BPNL of the issuing authority, if a Catena-X business partner.
+          pattern: "^BPNL[a-zA-Z0-9]{12}$"
+
+    CertificateValidator:
+      type: object
+      description: The party that can validate the certificate information.
+      required:
+        - validatorName
+      properties:
+        validatorName:
+          type: string
+          description: The name of the validator.
+        validatorBpn:
+          type: string
+          description: |
+            The BPNL of the validator. MAY be used as a free-text identifier where
+            a BPNL is not available.
+
+    CertificateDocument:
+      type: object
+      description: |
+        A certificate document. By default a reference whose binary is retrieved
+        via `GET /documents/{id}`. When embedded in a lifecycle notification to a
+        consumer registered under the `…ConsumerEmbeddedDocumentApi` subject, it
+        additionally carries the binary inline as `contentBase64` (CX-0135
+        §3.2.1). `contentBase64` MUST NOT be present in a `GET /certificates/{id}`
+        or `/certificates/search` response (CX-0135 §3.3.2).
+      required:
+        - documentId
+        - createdDate
+        - mediaType
+      properties:
+        documentId:
+          type: string
+          description: |
+            Opaque, revision-independent identifier of the document, used to
+            retrieve it via `GET /documents/{id}`.
+          example: "doc-3fa85f64-5717-4562-b3fc-2c963f66afa6"
+        createdDate:
+          type: string
+          format: date
+          description: The date the document was created (ISO 8601 full-date, `YYYY-MM-DD`).
+          example: "2023-01-25"
+        language:
+          type: string
+          description: |
+            Language of the document as an ISO 639-1 two-letter code (e.g. `en`,
+            `de`). Distinguishes documents that differ only by language.
+          pattern: "^[a-z]{2}$"
+          example: "en"
+        mediaType:
+          type: string
+          description: IANA media type of the document binary.
+          example: "application/pdf"
+        contentBase64:
+          type: string
+          format: byte
+          description: |
+            Base64-encoded document binary. Present only when the document is
+            embedded inline in a lifecycle notification (CX-0135 §3.2.1).

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/certificate-consumer-api.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/certificate-consumer-api.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Certificate Consumer Notification API
+  title: Certificate Consumer API
   description: |
     HTTP API exposed by a Certificate Consumer to receive notifications from
     Certificate Providers, as defined in CX-0135.
@@ -14,7 +14,7 @@ info:
 
     All requests MUST use HTTPS (TLS 1.2 or higher). Authorization MUST adhere
     to CX-0000 (CloudEventsFoundation).
-  version: 1.0.0
+  version: 3.0.0
 
 servers:
   - url: https://{base}
@@ -22,7 +22,7 @@ servers:
     variables:
       base:
         default: api.example.com
-        description: Host serving the Certificate Consumer Notification API
+        description: Host serving the Certificate Consumer API
 
 paths:
   /certificate-notifications:
@@ -59,7 +59,7 @@ paths:
                       - $ref: '#/components/schemas/CertificateFulfillmentStatusEvent'
             examples:
               created:
-                summary: Status CREATED
+                summary: Status CREATED (baseline subject — light triage)
                 value:
                   specversion: "1.0"
                   type: org.catena-x.ccm.CertificateLifecycleStatus.v1
@@ -70,11 +70,57 @@ paths:
                   datacontenttype: application/json
                   dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
                   data:
-                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
-                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
                     status: CREATED
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificate:
+                      certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                      revision: 1
+                      certificateType: iso9001
+                      validFrom: "2023-01-25"
+                      validUntil: "2026-01-24"
+              createdWithDocuments:
+                summary: Status CREATED (embedded-document subject — full record + content)
+                value:
+                  specversion: "1.0"
+                  type: org.catena-x.ccm.CertificateLifecycleStatus.v1
+                  source: urn:bpn:BPNL0000000001AB
+                  subject: BPNL0000000002CD
+                  id: e7c9a1b2-3d4e-5f6a-7b8c-9d0e1f2a3b4c
+                  time: "2025-05-04T07:00:00Z"
+                  datacontenttype: application/json
+                  dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
+                  data:
+                    status: CREATED
+                    exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                    certificate:
+                      certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                      revision: 1
+                      certificateType: iso9001
+                      certificateTypeVersion: "2015"
+                      registrationNumber: "12 100 4711"
+                      validFrom: "2023-01-25"
+                      validUntil: "2026-01-24"
+                      trustLevel: high
+                      areaOfApplication: Production and assembly of powertrain components
+                      certifiedLocations:
+                        - bpnl: BPNL00000001AXS
+                          bpna: BPNA00000001AXS
+                          bpns: BPNS00000001AXS
+                          locationRole: MAIN_LOCATION
+                      issuer:
+                        issuerName: TÜV Süd
+                        issuerBpn: BPNL0000000003EF
+                      validator:
+                        validatorName: TÜV Süd
+                        validatorBpn: BPNL0000000003EF
+                      documents:
+                        - documentId: doc-3fa85f64-5717-4562-b3fc-2c963f66afa6
+                          createdDate: "2023-01-25"
+                          language: en
+                          mediaType: application/pdf
+                          contentBase64: JVBERi0xLjQKJ...
               modified:
-                summary: Status MODIFIED (new version)
+                summary: Status MODIFIED (baseline subject)
                 value:
                   specversion: "1.0"
                   type: org.catena-x.ccm.CertificateLifecycleStatus.v1
@@ -85,10 +131,15 @@ paths:
                   datacontenttype: application/json
                   dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
                   data:
-                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
                     status: MODIFIED
+                    certificate:
+                      certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                      revision: 2
+                      certificateType: iso9001
+                      validFrom: "2023-01-25"
+                      validUntil: "2027-01-24"
               withdrawn:
-                summary: Status WITHDRAWN (no validity)
+                summary: Status WITHDRAWN
                 value:
                   specversion: "1.0"
                   type: org.catena-x.ccm.CertificateLifecycleStatus.v1
@@ -99,8 +150,9 @@ paths:
                   datacontenttype: application/json
                   dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
                   data:
-                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
                     status: WITHDRAWN
+                    certificate:
+                      certificateId: cert-550e8400-e29b-41d4-a716-446655440000
               batch:
                 summary: A batch of lifecycle status events
                 value:
@@ -113,9 +165,14 @@ paths:
                     datacontenttype: application/json
                     dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
                     data:
-                      exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
-                      certificateId: cert-550e8400-e29b-41d4-a716-446655440000
                       status: CREATED
+                      exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
+                      certificate:
+                        certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                        revision: 1
+                        certificateType: iso9001
+                        validFrom: "2023-01-25"
+                        validUntil: "2026-01-24"
                   - specversion: "1.0"
                     type: org.catena-x.ccm.CertificateLifecycleStatus.v1
                     source: urn:bpn:BPNL0000000001AB
@@ -125,8 +182,9 @@ paths:
                     datacontenttype: application/json
                     dataschema: https://w3id.org/catenax/schemas/ccm/certificate-lifecycle-status.json
                     data:
-                      certificateId: cert-770e8400-e29b-41d4-a716-446655449999
                       status: WITHDRAWN
+                      certificate:
+                        certificateId: cert-770e8400-e29b-41d4-a716-446655449999
               fulfillmentFulfilled:
                 summary: Fulfillment status FULFILLED
                 value:
@@ -312,24 +370,36 @@ components:
             The status value. Subtypes constrain the permitted set of values.
 
     CertificateLifecycleStatus:
+      type: object
       description: |
-        Certificate lifecycle status payload, derived from `CertificateStatusBase`.
-        `exchangeId` is present when `status` is `CREATED` (the event opens the
-        exchange) and absent for `MODIFIED`/`WITHDRAWN`. `validFrom` and
-        `validUntil` are REQUIRED when `status` is `CREATED` or `MODIFIED` and MAY
-        be omitted when `status` is `WITHDRAWN`.
-      allOf:
-        - $ref: '#/components/schemas/CertificateStatusBase'
-        - type: object
-          required:
-            - status
-          properties:
-            status:
-              type: string
-              enum: [CREATED, MODIFIED, WITHDRAWN]
-              description: |
-                The lifecycle status. `CREATED` opens a Certificate Exchange;
-                `MODIFIED` and `WITHDRAWN` do not.
+        Certificate lifecycle status payload. Carries the event `status`, the
+        `exchangeId` (only on `CREATED`, which opens a provider-initiated
+        exchange), and the `certificate` record. The populated field set of
+        `certificate` depends on the Certificate Consumer's API subject:
+        under `cx-taxo:CompanyCertificateManagementConsumerApi` it carries the
+        light triage subset (`certificateId`, `revision`, `certificateType`,
+        `validFrom`, `validUntil`); under
+        `cx-taxo:CompanyCertificateManagementConsumerEmbeddedDocumentApi` it
+        carries the full record plus `documents[].contentBase64`. A `WITHDRAWN`
+        event carries only `certificate.certificateId`. Per-status / per-subject
+        presence is defined in CX-0135 §3.2.1.
+      required:
+        - status
+        - certificate
+      properties:
+        status:
+          type: string
+          enum: [CREATED, MODIFIED, WITHDRAWN]
+          description: |
+            The lifecycle status. `CREATED` opens a Certificate Exchange;
+            `MODIFIED` and `WITHDRAWN` do not.
+        exchangeId:
+          type: string
+          description: |
+            Identifier of the provider-initiated Certificate Exchange opened by a
+            `CREATED` event. Present only for `CREATED`.
+        certificate:
+          $ref: './ccm-schemas.yaml#/components/schemas/Certificate'
 
     CertificateFulfillmentStatusEvent:
       type: object
@@ -398,9 +468,10 @@ components:
               type: string
               enum: [ACKNOWLEDGED, CERTIFICATION_REQUESTED, FULFILLED, DECLINED, FAILED]
               description: |
-                The Fulfillment status. Providers SHOULD push at least the
-                terminal outcomes (`FULFILLED`, `DECLINED`, `FAILED`);
-                intermediate states MAY also be pushed.
+                The Fulfillment status. Providers MUST push all provider-owned
+                terminal outcomes (`FULFILLED`, `DECLINED`, `FAILED`) to a
+                Consumer that exposes this API (CX-0135 §3.2.1); intermediate
+                states MAY also be pushed.
             errors:
               type: array
               description: |

--- a/docs/standards/CX-0135-CompanyCertificateManagement/assets/certificate-provider-api.yaml
+++ b/docs/standards/CX-0135-CompanyCertificateManagement/assets/certificate-provider-api.yaml
@@ -7,13 +7,13 @@ info:
     acceptance status updates, and answer certificate queries, as defined in
     CX-0135.
 
-    A certificate is identified by the (`certificateId`, `version`) pair. A
+    A certificate is identified by the (`certificateId`, `revision`) pair. A
     consumer-initiated request opens a Certificate Exchange; the Certificate
-    Provider assigns `certificateId` and `version` when it accepts the request.
+    Provider assigns `certificateId` and `revision` when it accepts the request.
 
     All requests MUST use HTTPS (TLS 1.2 or higher). Authorization MUST adhere
     to CX-0000 (CloudEventsFoundation).
-  version: 1.0.0
+  version: 3.0.0
 
 servers:
   - url: https://{base}
@@ -31,7 +31,7 @@ paths:
         Invoked by a Certificate Consumer to request a certificate. A request
         opens a consumer-initiated Certificate Exchange. On acceptance the
         Certificate Provider assigns and returns a `certificateId` and
-        `version`, enabling the consumer to poll fulfillment status and later
+        `revision`, enabling the consumer to poll fulfillment status and later
         retrieve the certificate.
       operationId: createCertificateRequest
       requestBody:
@@ -44,14 +44,14 @@ paths:
               byType:
                 summary: Request a certificate by type and location
                 value:
-                  certificateType: ISO9001
-                  enclosedSiteBpns:
+                  certificateType: iso9001
+                  certifiedLocationBpns:
                     - BPNS00000003AYRE
       responses:
         '202':
           description: |
             The request was accepted. The body carries the assigned
-            `certificateId` and `version` and the current fulfillment status.
+            `certificateId` and `revision` and the current fulfillment status.
           content:
             application/json:
               schema:
@@ -62,21 +62,21 @@ paths:
                   value:
                     exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
                     certificateId: cert-550e8400-e29b-41d4-a716-446655440000
-                    version: 1
+                    revision: 1
                     status: ACKNOWLEDGED
                 fulfilled:
                   summary: Certificate already available
                   value:
                     exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
                     certificateId: cert-550e8400-e29b-41d4-a716-446655440000
-                    version: 1
+                    revision: 1
                     status: FULFILLED
                 declined:
                   summary: Request refused
                   value:
                     exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
                     certificateId: cert-550e8400-e29b-41d4-a716-446655440000
-                    version: 1
+                    revision: 1
                     status: DECLINED
                     errors:
                       - message: Certificate type not offered for the requested location
@@ -98,12 +98,12 @@ paths:
         Fulfillment phase; the consumer's acceptance outcome is reported
         separately via `POST /certificate-acceptance-notifications`.
 
-        Polling is optional: if the Certificate Consumer exposes the Certificate
-        Consumer Notification API, the Certificate Provider MAY instead push
-        these fulfillment status updates to it as a
-        `org.catena-x.ccm.CertificateFulfillmentStatus.v1` event (CX-0135). 
-        The push and the poll are equivalent and carry the same
-        `exchangeId` and `status`.
+        If the Certificate Consumer exposes the Certificate Consumer API, the
+        Certificate Provider MUST push fulfillment status updates to it
+        as a `org.catena-x.ccm.CertificateFulfillmentStatus.v1` event for all
+        provider-owned terminal states (CX-0135 §3.2.1). This poll endpoint then
+        serves as a fallback/recovery mechanism and carries the same `exchangeId`
+        and `status` as the pushed event.
       operationId: getCertificateRequestStatus
       parameters:
         - name: id
@@ -127,21 +127,21 @@ paths:
                   value:
                     exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
                     certificateId: cert-550e8400-e29b-41d4-a716-446655440000
-                    version: 1
+                    revision: 1
                     status: ACKNOWLEDGED
                 fulfilled:
                   summary: Status FULFILLED
                   value:
                     exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
                     certificateId: cert-550e8400-e29b-41d4-a716-446655440000
-                    version: 1
+                    revision: 1
                     status: FULFILLED
                 declined:
                   summary: Status DECLINED
                   value:
                     exchangeId: exch-7f3a9c12-4b8e-4d6a-9e21-0c5b2a1d8f44
                     certificateId: cert-550e8400-e29b-41d4-a716-446655440000
-                    version: 1
+                    revision: 1
                     status: DECLINED
                     errors:
                       - message: Certificate type not offered for the requested location
@@ -162,10 +162,10 @@ paths:
         certificate is metadata only; binary documents are not included. Each
         associated document is listed by reference in the `documents` array and
         retrieved independently via `GET /documents/{id}`.
-        Returns the latest version by default; a specific version may be
-        requested with the `version` query parameter (e.g. to retrieve the exact
-        version a Certificate Exchange concerns). The provider MUST be able to
-        return any version still referenced by a non-terminal Certificate
+        Returns the latest revision by default; a specific revision may be
+        requested with the `revision` query parameter (e.g. to retrieve the exact
+        revision a Certificate Exchange concerns). The provider MUST be able to
+        return any revision still referenced by a non-terminal Certificate
         Exchange.
       operationId: getCertificate
       parameters:
@@ -175,24 +175,52 @@ paths:
           description: The unique identifier of the certificate.
           schema:
             type: string
-        - name: version
+        - name: revision
           in: query
           required: false
           description: |
-            The specific version to retrieve. If omitted, the latest version is
+            The specific revision to retrieve. If omitted, the latest revision is
             returned.
           schema:
             type: integer
       responses:
         '200':
           description: |
-            Certificate found. The response is the JSON metadata described by
-            `CertificateMetadata`, including the `documents` array referencing
-            the documents associated with the returned version.
+            Certificate found. For an active certificate the response is the JSON
+            metadata described by `CertificateMetadata`, including the `documents`
+            array referencing the documents associated with the returned revision.
+            A withdrawn certificate need not remain retrievable; in that case the
+            response is the minimal `WithdrawnCertificate` status body
+            (`certificateId` + `status: WITHDRAWN`), with no metadata or documents,
+            so a consumer holding the `certificateId` can still observe the
+            withdrawal (CX-0135 §3.3.2).
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CertificateMetadata'
+                oneOf:
+                  - $ref: '#/components/schemas/CertificateMetadata'
+                  - $ref: '#/components/schemas/WithdrawnCertificate'
+              examples:
+                active:
+                  summary: Active certificate (full metadata)
+                  value:
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    revision: 1
+                    certificateType: iso9001
+                    registrationNumber: "12 100 4711"
+                    validFrom: "2023-01-25"
+                    validUntil: "2026-01-24"
+                    trustLevel: high
+                    certifiedLocations:
+                      - bpnl: BPNL00000001AXS
+                        bpna: BPNA00000001AXS
+                        bpns: BPNS00000001AXS
+                        locationRole: MAIN_LOCATION
+                withdrawn:
+                  summary: Withdrawn certificate (status only)
+                  value:
+                    certificateId: cert-550e8400-e29b-41d4-a716-446655440000
+                    status: WITHDRAWN
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -210,9 +238,9 @@ paths:
         the document binary, served directly with the `Content-Type` set to the
         document's `mediaType` (e.g. `application/pdf`) as advertised in the
         certificate metadata.
-        A `documentId` is opaque and independent of any certificate version; the
-        same document may be referenced by multiple certificate versions, so no
-        `version` parameter is required.
+        A `documentId` is opaque and independent of any certificate revision; the
+        same document may be referenced by multiple certificate revisions, so no
+        `revision` parameter is required.
       operationId: getDocument
       parameters:
         - name: id
@@ -355,44 +383,70 @@ paths:
 
   /certificates/search:
     post:
-      summary: Search certificates shell descriptors.
+      summary: Search certificates
       description: |
-        Returns certificate shell descriptors matching the supplied search criteria. 
-        Based on CX-0002, Asset Administration Shell Registry Service Specification - Query Profile (SSP-004).
-        Not the full specification has to be supported. The schema below
-        defines the **MUST** criteria. [Everything else is optional and **MAY** be 
-        supported](https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/schemas/QueryResultAssetAdministrationShellDescriptor).
-        For further details about normative aspects of this API, please refer to CX-0135.
-        
-        Important: The response contains a shell descriptor href (or multiple, depending on the number of matches).
-        Every href **MUST** be an href according to CX-0002, that links to the /certificates/{id} endpoint 
-        (the submodel server) of this API, with the {id} being the certificateId of the matched certificate.
+        Returns the certificate records matching the supplied search criteria.
+        The query grammar and the mandatory field/operator subset are defined by
+        CX-0135 §3.3.4; a provider MUST support that subset and MAY support more,
+        rejecting a query that uses an unsupported field or operator with `501`.
+
+        Results are returned inline as full certificate records (without document
+        binaries). When the result set is paginated, pagination is conveyed via
+        the RFC 8288 `Link` response header (`next`/`prev`).
       operationId: queryCertificates
       parameters:
-        - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/parameters/Limit'
-        - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/parameters/Cursor'
+        - name: limit
+          in: query
+          required: false
+          description: |
+            Maximum number of results to return in a single page. If omitted, the
+            provider MAY apply a default limit.
+          schema:
+            type: integer
+            minimum: 1
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/CertificateQuery'
+            examples:
+              byLegalEntityAndType:
+                summary: Match a legal entity and a certificate type
+                value:
+                  $condition:
+                    $match:
+                      - $field: certifiedLocations.bpnl
+                        $eq: BPNL00000001AXS
+                      - $field: certificateType
+                        $eq: iso14001
       responses:
         '200':
-          description: Requested Asset Administration Shell Descriptors
+          description: |
+            Certificate records matching the query. When paginated, the `Link`
+            header carries `next`/`prev` URLs (RFC 8288).
+          headers:
+            Link:
+              description: |
+                Pagination links per RFC 8288. Present only on paginated
+                responses; a `next` or `prev` link is omitted when no further
+                results exist in that direction.
+              schema:
+                type: string
           content:
             application/json:
               schema:
-                $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/schemas/QueryResultAssetAdministrationShellDescriptor'
+                $ref: '#/components/schemas/CertificateQueryResponse'
         '400':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/bad-request'
+          $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/unauthorized'
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/forbidden'
+          $ref: '#/components/responses/Forbidden'
         '500':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/internal-server-error'
-        default:
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/default'
+          $ref: '#/components/responses/InternalServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 
 components:
   schemas:
@@ -406,12 +460,12 @@ components:
           type: string
           description: |
             Opaque string identifying the certificate type to be requested
-            (for example, `ISO9001`).
-        enclosedSiteBpns:
+            (for example, `iso9001`).
+        certifiedLocationBpns:
           type: array
           description: |
-            BPNs of the sites or addresses the request applies to. If omitted,
-            the request applies to the legal entity.
+            BPNs (BPNL, BPNS, or BPNA) of the certified locations the request
+            targets. If omitted, the request applies to the legal entity.
           items:
             type: string
 
@@ -423,7 +477,7 @@ components:
       required:
         - exchangeId
         - certificateId
-        - version
+        - revision
         - status
       properties:
         exchangeId:
@@ -436,9 +490,9 @@ components:
           description: |
             Identifier assigned to the requested certificate. Used to retrieve
             the certificate via `GET /certificates/{id}`.
-        version:
+        revision:
           type: integer
-          description: Version assigned to the requested certificate.
+          description: Revision assigned to the requested certificate.
         status:
           type: string
           enum: [ACKNOWLEDGED, CERTIFICATION_REQUESTED, FULFILLED, DECLINED]
@@ -458,7 +512,7 @@ components:
       required:
         - exchangeId
         - certificateId
-        - version
+        - revision
         - status
       properties:
         exchangeId:
@@ -469,9 +523,9 @@ components:
         certificateId:
           type: string
           description: Unique identifier of the requested certificate.
-        version:
+        revision:
           type: integer
-          description: The version of the requested certificate.
+          description: The revision of the requested certificate.
         status:
           type: string
           enum: [ACKNOWLEDGED, CERTIFICATION_REQUESTED, FULFILLED, DECLINED, FAILED]
@@ -484,165 +538,44 @@ components:
           items:
             $ref: '#/components/schemas/StatusError'
 
-    CertificateDocument:
+    CertificateMetadata:
+      description: |
+        A retrieved certificate record (CX-0135 §4). On retrieval the full record
+        is mandatory, and document content (`contentBase64`) MUST NOT be included
+        (CX-0135 §3.3.2). The field definitions are shared with the Certificate
+        Consumer API via `ccm-schemas.yaml`.
+      allOf:
+        - $ref: './ccm-schemas.yaml#/components/schemas/Certificate'
+        - type: object
+          required:
+            - revision
+            - certificateType
+            - registrationNumber
+            - validFrom
+            - validUntil
+            - trustLevel
+            - certifiedLocations
+
+    WithdrawnCertificate:
       type: object
       description: |
-        A reference to a document associated with a certificate version. The
-        binary is retrieved separately via `GET /documents/{id}`.
-      required:
-        - documentId
-        - mediaType
-      properties:
-        documentId:
-          type: string
-          description: |
-            Opaque, version-independent identifier of the document, used to
-            retrieve it via `GET /documents/{id}`.
-          examples:
-            - "doc-3fa85f64-5717-4562-b3fc-2c963f66afa6"
-        language:
-          type: string
-          description: |
-            Language of the document as an ISO 639-1 two-letter code
-            (e.g. `en` for English, `de` for German). Distinguishes documents
-            that differ only by language.
-          pattern: "^[a-z]{2}$"
-          examples:
-            - "en"
-        mediaType:
-          type: string
-          description: IANA media type of the document binary.
-          examples:
-            - "application/pdf"
-            - "image/png"
-
-    EnclosedSite:
-      type: object
-      description: A site or address a certificate applies to.
-      required:
-        - bpn
-      properties:
-        bpn:
-          type: string
-          description: |
-            The Business Partner Number of the site (BPNS) or address (BPNA)
-            the certificate covers.
-          pattern: "^BPN[SA][a-zA-Z0-9]{12}$"
-        areaOfApplication:
-          type: string
-          description: |
-            Free-text detail of the areas or application types the certificate
-            is valid for at this specific location.
-
-    CertificateIssuer:
-      type: object
-      description: The authority that issued the certificate.
-      required:
-        - issuerName
-      properties:
-        issuerName:
-          type: string
-          description: The name of the issuing authority (e.g. `TÜV Süd`).
-        issuerBpn:
-          type: string
-          description: The BPNL of the issuing authority, if a Catena-X business partner.
-          pattern: "^BPNL[a-zA-Z0-9]{12}$"
-
-    CertificateValidator:
-      type: object
-      description: The party that can validate the certificate information.
-      required:
-        - validatorName
-      properties:
-        validatorName:
-          type: string
-          description: The name of the validator.
-        validatorBpn:
-          type: string
-          description: |
-            The BPNL of the validator. MAY be used as a free-text identifier
-            where a BPNL is not available.
-
-    CertificateMetadata:
-      type: object
-      description: JSON metadata accompanying a retrieved certificate.
+        Minimal status body returned by `GET /certificates/{id}` for a withdrawn
+        certificate (CX-0135 §3.3.2). A withdrawn certificate need not remain
+        retrievable; this body lets a consumer holding the `certificateId` observe
+        the withdrawal. It carries no metadata or documents.
+      additionalProperties: false
       required:
         - certificateId
-        - version
-        - certificateType
-        - certifiedBpn
-        - registrationNumber
-        - validFrom
-        - validUntil
-        - trustLevel
+        - status
       properties:
         certificateId:
           type: string
-          description: |
-            Unique identifier of the certificate. Matches the `{id}` path
-            parameter of the request.
-        version:
-          type: integer
-          description: |
-            The version returned — the version requested via the `version` query
-            parameter, or the latest version if none was specified.
-        certificateType:
+          description: Unique identifier of the withdrawn certificate.
+          example: "cert-550e8400-e29b-41d4-a716-446655440000"
+        status:
           type: string
-          description: Opaque string identifying the certificate type (e.g. `ISO9001`).
-        certificateTypeVersion:
-          type: string
-          description: |
-            The version of the certificate type itself (e.g. `2015` for
-            ISO 9001:2015). Distinct from the certificate's `version`.
-        certifiedBpn:
-          type: string
-          description: The BPNL of the certified legal entity the certificate is issued on.
-          pattern: "^BPNL[a-zA-Z0-9]{12}$"
-        registrationNumber:
-          type: string
-          description: The certificate's registration number at the issuing body.
-        validFrom:
-          type: string
-          format: date
-          description: |
-            Inclusive start date of the certificate validity period
-            (ISO 8601 full-date, `YYYY-MM-DD`).
-        validUntil:
-          type: string
-          format: date
-          description: |
-            Inclusive end date of the certificate validity period
-            (ISO 8601 full-date, `YYYY-MM-DD`).
-        trustLevel:
-          type: string
-          description: The degree to which the certificate has been validated.
-          enum: [none, low, medium, high, trusted]
-        areaOfApplication:
-          type: string
-          description: |
-            Free-text detail of the areas or application types the certificate
-            is valid for overall. Individual locations MAY narrow this via
-            `Location.areaOfApplication`.
-        enclosedSites:
-          type: array
-          description: |
-            The sites or addresses the certificate applies to. If omitted or
-            empty, the certificate applies to the issuing legal entity as a
-            whole.
-          items:
-            $ref: '#/components/schemas/EnclosedSite'
-        issuer:
-          $ref: '#/components/schemas/CertificateIssuer'
-        validator:
-          $ref: '#/components/schemas/CertificateValidator'
-        documents:
-          type: array
-          description: |
-            Documents associated with this certificate version. Each document is
-            retrieved independently via `GET /documents/{id}`. If omitted or
-            empty, the version has no associated documents.
-          items:
-            $ref: '#/components/schemas/CertificateDocument'
+          enum: [WITHDRAWN]
+          description: Lifecycle status of the certificate.
 
     CertificateAcceptanceStatusEvent:
       type: object
@@ -752,60 +685,61 @@ components:
             the certificate, such as a site BPN. If omitted, the error
             applies to the certificate as a whole.
 
-    standardString:
-      type: string
-      pattern: ^(?!\$).*
-    modelStringPattern:
-      type: string
-      pattern: ^(?:\$aas#(?:idShort|id|assetInformation\.assetKind|assetInformation\.assetType|assetInformation\.globalAssetId|assetInformation\.specificAssetIds\[[0-9]*\]\.(?:name|value|externalSubjectId(?:\.(?:type|keys\[[0-9]*\]\.(?:type|value)))?)|submodels\[[0-9]*\]\.(?:type|keys\[[0-9]*\]\.(?:type|value)))|\$sm#(?:semanticId(?:\.(?:type|keys\[[0-9]*\]\.(?:type|value)))?|idShort|id)|\$sme(?:\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\[[0-9]*\])*(?:\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\[[0-9]*\])*)*)?#(?:semanticId(?:\.(?:type|keys\[[0-9]*\]\.(?:type|value)))?|idShort|value|valueType|language)|\$cd#(?:idShort|id)|\$aasdesc#(?:idShort|id|assetKind|assetType|globalAssetId|specificAssetIds\[[0-9]*\]\.(?:name|value|externalSubjectId(?:\.(?:type|keys\[[0-9]*\]\.(?:type|value)))?)|endpoints\[[0-9]*\]\.(?:interface|protocolinformation\.href)|submodelDescriptors\[[0-9]*\]\.(?:semanticId(?:\.(?:type|keys\[[0-9]*\]\.(?:type|value)))?|idShort|id|endpoints\[[0-9]*\]\.(?:interface|protocolinformation\.href)))|\$smdesc#(?:semanticId(?:\.(?:type|keys\[[0-9]*\]\.(?:type|value)))?|idShort|id|endpoints\[[0-9]*\]\.(?:interface|protocolinformation\.href)))$
-    Value:
+    CertificateQuery:
       type: object
-      properties:
-        $field:
-          $ref: "#/components/schemas/modelStringPattern"
-        $strVal:
-          $ref: "#/components/schemas/standardString"
-      oneOf:
-        - required:
-            - $field
-        - required:
-            - $strVal
+      description: |
+        Self-contained CCM certificate query (CX-0135 §3.3.4). A single root
+        `$condition` whose `$match` array combines its clauses with logical AND.
+      required:
+        - $condition
       additionalProperties: false
-    comparisonItems:
-      type: array
-      minItems: 2
-      maxItems: 2
-      items:
-        $ref: "#/components/schemas/Value"
-    matchExpression:
-      type: object
       properties:
-        $eq:
-          $ref: "#/components/schemas/comparisonItems"
-      oneOf:
-        - required:
-            - $eq
-      additionalProperties: false
-    logicalExpression:
+        $condition:
+          $ref: '#/components/schemas/Condition'
+    Condition:
       type: object
+      required:
+        - $match
+      additionalProperties: false
       properties:
         $match:
           type: array
           minItems: 1
+          description: |
+            Comparison clauses combined with logical AND; a certificate matches
+            only if it satisfies every clause.
           items:
-            $ref: "#/components/schemas/matchExpression"
-      oneOf:
-        - required:
-            - $match
-      additionalProperties: false
-    CertificateQuery:
+            $ref: '#/components/schemas/MatchClause'
+    MatchClause:
       type: object
-      properties:
-        $condition:
-          $ref: "#/components/schemas/logicalExpression"
+      description: An equality comparison of a single field against a string value.
       required:
-        - $condition
+        - $field
+        - $eq
       additionalProperties: false
+      properties:
+        $field:
+          type: string
+          description: |
+            Dotted path of the field to compare. Providers MUST support at least
+            `certifiedLocations.bpnl`, `certifiedLocations.bpns`,
+            `certifiedLocations.bpna`, and `certificateType`, and MAY support
+            more; an unsupported field MUST be rejected with `501`.
+          pattern: '^[a-zA-Z]+(\.[a-zA-Z]+)*$'
+          example: certifiedLocations.bpnl
+        $eq:
+          type: string
+          description: The string value the field must equal.
+          example: BPNL00000001AXS
+    CertificateQueryResponse:
+      type: array
+      description: |
+        Certificate records matching a query. Each item is the full certificate
+        metadata for the latest revision (without document binaries). A consumer
+        retrieves the certificate via `GET /certificates/{id}` using its
+        `certificateId`.
+      items:
+        $ref: '#/components/schemas/CertificateMetadata'
 
     Error:
       type: object
@@ -843,6 +777,14 @@ components:
             $ref: '#/components/schemas/Error'
     InternalServerError:
       description: An unexpected error occurred on the server.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotImplemented:
+      description: |
+        The query uses a field or operator the provider does not support
+        (CX-0135 §3.3.4).
       content:
         application/json:
           schema:


### PR DESCRIPTION
# CX-0135 Company Certificate Management v3.0.0 — Spec/OpenAPI alignment and self-containment

## Summary

This PR brings the CX-0135 v3.0.0 standard text and its two OpenAPI contracts into full alignment, makes the standard
**normatively self-contained** (no normative dependency on external data artifacts or the AAS/Digital-Twin stack), and
adds a set of targeted improvements (security section, worked examples, withdrawal handling, a capability matrix) plus a
document-wide consistency and wording pass.

Headline outcomes:

- **The standard is the normative authority for its own data model and APIs.** As written, several normative references
  reached outside the standard into the broader Asset Administration Shell (AAS) stack and into versioned, non-standard
  artifacts — the SSP-004 query profile (via CX-0002), the CX-0002 submodel retrieval coupling, and the SAMM aspect
  model `4.0.0` — each of which evolves on its own cadence, outside this standard's change control. A change to any of
  them could silently alter or break conformance, and in the aspect model's case the mandated version is not even
  published. Two distinct corrections follow. **(a) The AAS-based wire formats were removed (not retained).**
  `GET /certificates/{id}` no longer returns an AAS *submodel* serialization — which would have obliged every provider
  to stand up an AAS submodel server (the Digital-Twin/AAS submodel API) to hand back certificate data — and the search
  endpoint no longer returns AAS *shell descriptors*, which forced an **N+1 retrieval pattern**: the search returns
  descriptors/hrefs, and the consumer must then make a separate fetch for each result. Both are replaced by
  self-contained JSON — a flat certificate record and a plain array of records — retrievable in a single call, with no
  AAS server in the path. **(b) The remaining external references are now informative rather than normative.** The data
  model is defined directly in the standard (§4.2 + the OpenAPI contracts), with the SSP-004 query profile and the SAMM
  aspect model kept only as non-normative compatibility/alignment notes (the standard takes precedence on any
  discrepancy). The result is that every remaining **normative** reference is an actual published specification (CX
  standards, CloudEvents 1.0.2 + HTTP binding, RFC 2119/8174/8288, ISO 639-1), and the standard can be implemented from
  its own text — with no AAS / Digital-Twin stack required.
- **A single, consistent push/notification model across all flows.** The push content was cleaned up and harmonized so
  the consumer-initiated, provider-initiated, and feedback flows behave uniformly. Every notification is a CloudEvent
  with the same `data.certificate` envelope; the provider's push obligation is now a guaranteed **MUST** (with polling
  reframed as a fallback, not an equivalent path); whether a notification carries the lightweight triage subset or the
  full record plus inline document binaries is driven by a single **API-subject opt-in** rather than ad-hoc flags; and
  document content lives in exactly one place — inline only in an embedded notification, otherwise retrieved by
  reference via `GET /documents/{id}`. Worked examples were added for the lifecycle, fulfillment, and acceptance event
  types so each flow is illustrated end to end.
- **Spec ↔ OpenAPI consistency.** The data model, query grammar, status enums, event types, version numbers, and
  examples now match across the spec and both contracts.
- **Single source of truth for the certificate record.** The shared data model lives in a new
  `assets/ccm-schemas.yaml`, referenced by both API contracts.
- **New normative content.** A Security & Authorization section (incl. sender-identity verification), withdrawal
  handling, and a per-capability API matrix.
- **DSP-aligned pagination.** The search endpoint now paginates via **RFC 8288 `Link` headers** (`next`/`prev`),
  replacing the removed external (SwaggerHub/AAS) cursor parameters. This matches the HTTP/Web-Linking conventions used
  by the **Dataspace Protocol (DSP)**, so CCM pagination behaves consistently with the rest of the dataspace rather
  than introducing an AAS-specific paging model.

## Files changed

| File                                      | Status   | Scope                                                    |
|-------------------------------------------|----------|----------------------------------------------------------|
| `CX-0135-CompanyCertificateManagement.md` | modified | spec text — data model, APIs, policy, structure, wording |
| `assets/certificate-provider-api.yaml`    | modified | Provider API contract                                    |
| `assets/certificate-consumer-api.yaml`    | modified | Consumer API contract                                    |
| `assets/ccm-schemas.yaml`                 | **new**  | shared certificate data-model schemas                    |

> Final §3 structure after this PR: **3.1 Security and Authorization**, **3.2 Certificate Consumer API**
> (3.2.1 Lifecycle Events, 3.2.2 Acceptance Status Query), **3.3 Certificate Provider API** (3.3.1 Request,
> 3.3.2 Retrieval, 3.3.3 Acceptance, 3.3.4 Query), **3.4 Policy Constraints**, **3.5 Usage Policy**,
> **3.6 DSP Dataset Representation**.

---

## 1. Self-contained standard — external dependencies demoted

The standard previously took normative dependencies on the AAS / CX-0002 stack and on an unpublished SAMM model. All
three are now non-normative; the equivalent content is defined inline.

- **CX-0002 / SSP-004 query profile (§3.3.4).** Removed "MUST implement … according to SSP-004 defined in CX-0002". The
  query grammar is now defined inline (see §3), and SSP-004 is a non-normative compatibility note ("implementing SSP-004
  in full is NOT required"). *Why:* a normative SSP-004 reference transitively pulls in the whole AAS Part 2 API
  surface, a larger operator set than needed, external version drift, and a conformance-suite mismatch — and CX-0002
  does not actually contain the grammar (it classifies SSP-004 as MAY/SHOULD).
- **CX-0002 submodel retrieval (§3.3.2).** `GET /certificates/{id}` no longer "MUST be based on CX-0002 / return the
  certificate submodel". It returns a flat JSON object conforming to the §4.1 data model — which is what the OpenAPI
  always returned. *Why:* a flat JSON object is not an AAS submodel, so the contract and the spec previously mandated
  different wire formats. CX-0002 was the last normative use, so it moved from §5.1 Normative to §5.2 Non-Normative, and
  §1.1 no longer says "builds upon … CX-0002".
- **SAMM aspect model `4.0.0` (§4.1).** Replaced "the semantic model MUST use `…:4.0.0`" with: the data model is defined
  normatively by **§4.2 + the `CertificateMetadata` OpenAPI schema**; the SAMM model is an informative convenience that
  SHOULD align with this section, and "in case of discrepancy, this standard takes precedence". The reference moved to
  §5.2 Non-Normative. *Why:* a standard's normative references must be stable published specifications; the mandated
  `4.0.0` is a `.ttl` data artifact that is not even published (upstream tops out at 3.1.0). The normative model was
  already fully present in §4.2 + the OpenAPI, so this leaves no gap and inverts the risk (a future model must follow
  the spec).

---

## 2. Certificate data model (§4)

The spec §4 is the data-model baseline; the OpenAPI was changed to match it (except where noted).

- **`version` → `revision`** everywhere (query param, `CertificateRequestResponse`, `CertificateRequestStatus`,
  `CertificateMetadata`, examples, prose). §4.2.11 defines `revision` as the counter that increments on **every**
  update (incl. non-version-affecting changes such as a `trustLevel` re-validation).
- **Structured locations.** Replaced the flat `EnclosedSite` list with **`CertifiedLocation`** (`bpnl`, `bpna`
  [required], `bpns`, `locationRole` enum, `areaOfApplication`); `certifiedLocations` has `minItems: 1` to enforce
  §4.2.4's "exactly one `MAIN_LOCATION`". The request filter field is `certifiedLocationBpns` (a plain BPN array).
- **Holder is derived** from `certifiedLocations[locationRole=MAIN_LOCATION].bpnl`; the redundant `certifiedBpn`
  field was removed (§4.2.9).
- **`trustLevel` enum** `[none, low, medium, high, trusted]` → **`[low, medium, high]`** (§4.2.6 defines exactly three
  process-based levels, with a migration mapping for the old five).
- **`mediaType`, not `contentType`** for a document's media type (§4.2.10) — `application/pdf` is an IANA media type;
  `mediaType` matches the sibling `language` field and was already the YAML's name.
- **`createdDate`** (required, `format: date`) added to the document model (§4.2.10).
- **`language`** (MAY, ISO 639-1) kept and documented in §4.2.10 — it supports the "different language versions"
  feature §4.1 introduces.

---

## 3. Certificate query & search endpoint (§3.3.4)

The search endpoint is now a self-contained, vendor-neutral contract.

- **Inline grammar.** `CertificateQuery` → `Condition` → `MatchClause`, where a clause is the flat
  `{ "$field": <string>, "$eq": <string> }`. `$match` AND-semantics stated normatively. (Replaced the AAS-derived
  `Value`/`comparisonItems`/`matchExpression`/`logicalExpression` schemas and the invalid 2-element-array `$eq`.)
- **Plain dotted `$field` paths** (`^[a-zA-Z]+(\.[a-zA-Z]+)*$`), tied to the aspect model, kept a **free string** so
  providers MAY support more fields. The field-name was corrected from the non-existent `type.certificateType` to
  top-level **`certificateType`**.
- **`HTTP 501`** for any field/operator outside the mandatory subset (a local `NotImplemented` response).
- **Self-contained response.** `CertificateQueryResponse` = a **plain array of `CertificateMetadata`** (full record, no
  document binaries) — not AAS shell descriptors, removing the N+1 search→GET round-trip. A consumer retrieves a
  certificate by `certificateId` via `GET /certificates/{id}` (no per-certificate `datasetId`; the Provider API is
  registered as a single asset).
- **Pagination = RFC 8288 `Link` header** (`next`/`prev`), aligned with DSP/HTTP. Added the `[RFC8288]` normative
  reference.
- **Removed all external SwaggerHub `$ref`s** — pagination params, the `200` schema, and error responses are now local.
  *Why:* remote runtime `$ref`s make the contract non-reproducible and expose it to upstream drift.
- A non-normative **example query result** was added.

---

## 4. Certificate retrieval (§3.3.2)

- **Self-contained JSON.** `GET /certificates/{id}` returns the certificate as a JSON object conforming to §4.1, as
  specified by the OpenAPI — not an AAS submodel (see §1). Documents are **references only**; content is fetched via
  `GET /documents/{id}` (or delivered inline in an embedded notification). `contentBase64` is forbidden on
  retrieval/search.
- **Withdrawal handling (new).** A withdrawn certificate need not remain retrievable, but its status stays observable:
  for a withdrawn `certificateId`, `GET /certificates/{id}` **MUST** return `HTTP 200` with a minimal body
  `{ "certificateId": …, "status": "WITHDRAWN" }` (no metadata/documents). The provider MAY stop serving the
  record/documents but MUST retain the withdrawn fact; an unknown id still returns `404`. OpenAPI: the `200` is now
  `oneOf [CertificateMetadata, WithdrawnCertificate]` with `active`/`withdrawn` examples, plus a new
  `WithdrawnCertificate` schema (`additionalProperties: false`; required `certificateId` + `status` enum
  `[WITHDRAWN]`).

---

## 5. Notifications — lifecycle, fulfillment, acceptance (§3.2.1, §3.3.3)

The notification payload was redesigned so a consumer can triage without a round-trip, and an opted-in consumer can
avoid the document fetch entirely.

- **`data.certificate` wrapper.** A lifecycle event's `data` = `{ status, exchangeId?, certificate }`. Both consumer
  subjects use the same shape, differing only in how much of `certificate` is populated.
- **Baseline (lightweight) vs embedded (full).**
    - **Baseline** (`…ConsumerApi` subject): `certificate` carries only the five-field triage subset —
      `certificateId`, `revision`, `certificateType`, `validFrom`, `validUntil` (no `trustLevel`, no locations, no
      documents) — enough to filter relevance without retrieving.
    - **Embedded** (`…ConsumerEmbeddedDocumentApi` subject): `CREATED`/`MODIFIED` events carry the **complete** record
      (identical to `GET`) plus `documents[].contentBase64` (inline binaries). A `WITHDRAWN` event carries only
      `certificateId`.
- **Opt-in via a distinct API subject, not a `dct:` flag.** Embedded delivery is signalled by registering the
  `…ConsumerEmbeddedDocumentApi` subject (the provider keys behaviour on the declared subject). *Why the earlier
  `dct:notification-payload` flag was wrong:* (1) `dct:` is the Dublin Core Terms controlled vocabulary, which CCM does
  not own — `notification-payload` is not a DCMI term; (2) JSON-LD `@id` is an IRI and cannot hold a boolean, so
  `{ "@id": "true" }` does not type-check as a flag. The subject approach reuses the existing `cx-taxo:` taxonomy with
  no new term.
- **One document schema, two strictness levels.** `contentBase64` is an **optional** field of the shared
  `CertificateDocument`; it is forbidden on `GET`/`search` (by prose) and present only on
  `data.certificate.documents[]` in an embedded notification. `GET` re-imposes its mandatory field set via `allOf`.
- **Worked examples** added/updated: two `CREATED` examples (baseline + embedded), a **fulfillment-status** example
  (`CertificateFulfillmentStatus.v1`, `FULFILLED`), and **acceptance-status** examples
  (`CertificateAcceptanceStatus.v1`, `ACCEPTED` and `REJECTED` with an `errors` array). §3.2.2 (Acceptance Status Query)
  gained a description; the acceptance event type is now named in the spec (§3.3.3).

---

## 6. Provider push obligation (§3.2)

The v3 "push-pull harmonization" only delivers value if push is guaranteed; the YAMLs had weakened it to MAY/SHOULD.

- Provider `getCertificateRequestStatus`: push of all provider-owned terminal states is now **MUST** when the Consumer
  exposes the Consumer API; polling is reframed as a **fallback/recovery** mechanism, not an equivalent alternative.
- Consumer `CertificateFulfillmentStatus.status`: **SHOULD → MUST** for provider-owned terminal outcomes (`FULFILLED`/
  `DECLINED`/`FAILED`); intermediate states remain MAY.
- The MUST is deliberately **conditional**: it applies only to endpoints the Consumer actually serves (an `HTTP 501`
  relieves the Provider of pushing to that endpoint), so it never conflicts with a Consumer declining an endpoint.

---

## 7. Security and Authorization (new §3.1)

A new normative section, placed before the API definitions:

- **Transport.** All endpoints MUST use HTTPS (TLS 1.2+).
- **Authorization.** Access is mediated by the Dataspace Protocol — a negotiated contract + access token (per CX-0000),
  bound by the §3.5 usage policy (incl. `cx.ccm.base:1`).
- **Sender-identity verification (the real gap).** A recipient MUST verify that a CloudEvent's `source` BPN matches the
  authenticated sender and MUST reject on mismatch (Consumer vs the pushing Provider; Provider vs the acceptance-sending
  Consumer).
- **Document confidentiality.** `contentBase64` is delivered inline only to a consumer registered under the
  embedded-document subject and authorized via its contract; binaries are served only over the authenticated channel.

---

## 8. Policy and DSP dataset representation (§3.4–§3.6)

The examples were made vendor-neutral (DSP/DCAT, not EDC-specific).

- **Removed the two "Example Certificate EDC Asset" blocks** (`@type: Asset`, `dataAddress`/`HttpData`/`proxy*`).
- **Added §3.6 "DSP Dataset Representation" (non-normative)** — two DCAT `dcat:Dataset` examples (Consumer and
  Provider), each with `dct:type`/`dct:subject`/`cx-common:version`, an `odrl:hasPolicy` block reproducing the §3.5
  usage policy (`FrameworkAgreement` + `UsagePurpose: cx.ccm.base:1`), and a `dcat:distribution`. The concrete transport
  binding is stated to be connector-specific and out of scope. IRI references use the explicit
  `{ "@id": … }` form (verified against the `dct` and Eclipse DSP contexts — neither coerces these terms, so a bare
  string would be read as a literal); genuine literals stay bare.
- **§3.4 Policy Constraints** tightened to its single requirement: access/usage policies MUST conform to CX-0152; the
  CCM usage policy is in §3.5.
- **§3.5 Usage Policy** example de-EDC'd: the policy is shown under `odrl:hasPolicy` (part of a Dataset) rather than as
  a standalone EDC policy-definition object. A note records that the offer `@id` is required by DSP but its value is
  connector-assigned/illustrative.

---

## 9. API versioning (§3, both YAMLs)

Three independent version numbers were in play (document 3.0.0, aspect model 4.0.0, OpenAPI 1.0.0). Decision: the
**OpenAPI contracts track the document version**; the aspect model stays on its own cadence.

- Both YAMLs: `info.version` **1.0.0 → 3.0.0**.
- Spec: every registered API-version reference **1.0 → 3.0** (§3 asset table, the §3.2/§3.3 "reference the version"
  rules, the asset-example `cx-common:version` blocks). The 2-part `cx-common:version` form is retained per Catena-X
  convention; `info.version` keeps the 3-part semver.
- A **version-triple note** in §1.2 states the three numbers are independent and not expected to match.

---

## 10. Shared schema file (`assets/ccm-schemas.yaml`, new)

Single source of truth for the certificate data model, referenced by both API contracts:

- `Certificate` (all fields; `required: [certificateId]` only), `CertifiedLocation`, `CertificateIssuer`,
  `CertificateValidator`, `CertificateDocument` (with optional `contentBase64`).
- Provider `CertificateMetadata` = `allOf [ ccm-schemas#Certificate, { required: [revision, certificateType,
  registrationNumber, validFrom, validUntil, trustLevel, certifiedLocations] } ]` — strict `GET` over the shared,
  lenient base.
- Consumer `CertificateLifecycleStatus` references `ccm-schemas#Certificate` for `data.certificate`.

> Cross-file `$ref` (`./ccm-schemas.yaml#…`) was reviewed: the docs site serves the YAMLs as linked static files (no
> OpenAPI renderer), and the refs resolve for co-located tooling. Kept as-is by decision.

---

## 11. Structure, cross-references, and OpenAPI conformance

- **Section renumbering.** Inserting §3.1 Security renumbered §3 (Consumer API → 3.2, Provider API → 3.3, Policy → 3.4,
  Usage Policy → 3.5, DSP Dataset → 3.6, with sub-sections); closed a §3.2.2 gap; closed a §4.2.5–4.2.11 gap. Every
  cross-reference, anchor, and `§3.x` mention in the spec **and** the YAMLs was updated; a full link scan reports zero
  unresolved internal anchors.
- **Capability matrix (§3).** A table mapping participant capability (offer certificates / receive
  notifications+feedback / Business Application Provider) to which API it MUST expose.
- **Cross-reference & numbering fixes** (§1.2, §3, §4.2): corrected stale section targets (e.g. data model is §4, not
  §5), a `MOST → MUST` typo, a CERTIFICATE HOLDER heading level, and several stale anchors from earlier numbering;
  removed a leftover `TODO` block.
- **OpenAPI 3.0.3 conformance.** In `CertificateDocument`, schema-level `examples:` (3.1-only) → `example:`
  (singular) for `documentId`/`createdDate`/`language`/`mediaType`. Media-Type-level `examples:` (valid) left as-is.
- **`revision` description fixed** (§4.2.11): the unimplementable "MUST be used for concurrency control" claim (there is
  no update endpoint and no `If-Match`/`ETag`/`409`) was reworded to `revision`'s actual role — version identity, update
  detection, and pinning the revision an exchange/acceptance concerns.
- **Casing/example fixes:** `ISO9001 → iso9001` (§4.2.1 mandates lowercase); Consumer API title "…Notification API"
  → "Certificate Consumer API"; Dublin Core reference links → canonical `https` DCMI URLs (the JSON-LD `@context`
  namespace IRI intentionally left as `http`, as it is the canonical RDF identifier).

---

## 12. Wording-consistency pass

A document-wide editorial sweep (anchors and JSON examples verified intact throughout):

- Defined terms cased consistently — `certificate exchange` → **Certificate Exchange**, `certificate consumer` →
  **Certificate Consumer**, `business application provider` → **Business Application Provider**.
- Role shorthand capitalized — standalone `provider`/`consumer` → **Provider**/ **Consumer** (55 nouns; hyphenated
  compounds like `provider-owned`/`consumer-initiated` left lowercase).
- Single term for the record — **`certificate record`** for the object; `certificate metadata` kept only where it
  contrasts with document content; the two loose `certificate information` uses converted.
- `the Provider API` → **the Certificate Provider API** (canonical); `provider owned` → `provider-owned`;
  `subchapter (s)` → `subsection(s)`; 4 unspaced em-dashes normalized to the spaced ` — ` form.

---
